### PR TITLE
libsysnds: introduce agbabi-derived fast memcpy/memmove routines

### DIFF
--- a/libs/libsysnds/Makefile.arm7
+++ b/libs/libsysnds/Makefile.arm7
@@ -9,8 +9,8 @@ endif
 # Source code paths
 # -----------------
 
-SOURCEDIRS	:= source/arm7
-INCLUDEDIRS	:=
+SOURCEDIRS	:= source/common source/arm7
+INCLUDEDIRS	:= source/common/ndsabi
 
 # Defines passed to all files
 # ---------------------------

--- a/libs/libsysnds/Makefile.arm9
+++ b/libs/libsysnds/Makefile.arm9
@@ -9,8 +9,8 @@ endif
 # Source code paths
 # -----------------
 
-SOURCEDIRS	:= source/arm9
-INCLUDEDIRS	:= include
+SOURCEDIRS	:= source/common source/arm9
+INCLUDEDIRS	:= source/common/ndsabi include
 
 # Defines passed to all files
 # ---------------------------

--- a/libs/libsysnds/include/aeabi.h
+++ b/libs/libsysnds/include/aeabi.h
@@ -67,6 +67,53 @@ void __aeabi_memmove4(void* dest, const void* src, size_t n) __attribute__((nonn
  */
 void __aeabi_memmove(void* dest, const void* src, size_t n) __attribute__((nonnull(1, 2)));
 
+/**
+ * Alias of __aeabi_memset4
+ * @param dest Destination address
+ * @param n Number of bytes to set
+ * @param c Value to set
+ */
+void __aeabi_memset8(void* dest, size_t n, int c) __attribute__((nonnull(1)));
+
+/**
+ * Set n bytes of dest to (c & 0xff)
+ * Assumes dest is 4-byte aligned
+ * @param dest Destination address
+ * @param n Number of bytes to set
+ * @param c Value to set
+ */
+void __aeabi_memset4(void* dest, size_t n, int c) __attribute__((nonnull(1)));
+
+/**
+ * Set n bytes of dest to (c & 0xff)
+ * @param dest Destination address
+ * @param n Number of bytes to set
+ * @param c Value to set
+ */
+void __aeabi_memset(void* dest, size_t n, int c) __attribute__((nonnull(1)));
+
+/**
+ * Alias of __aeabi_memclr4
+ * @param dest Destination address
+ * @param n Number of bytes to clear
+ */
+void __aeabi_memclr8(void* dest, size_t n) __attribute__((nonnull(1)));
+
+/**
+ * Clears n bytes of dest to 0
+ * Assumes dest is 4-byte aligned
+ * @param dest Destination address
+ * @param n Number of bytes to clear
+ */
+void __aeabi_memclr4(void* dest, size_t n) __attribute__((nonnull(1)));
+
+/**
+ * Clears n bytes of dest to 0
+ * @param dest Destination address
+ * @param n Number of bytes to clear
+ */
+void __aeabi_memclr(void* dest, size_t n) __attribute__((nonnull(1)));
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/libsysnds/include/aeabi.h
+++ b/libs/libsysnds/include/aeabi.h
@@ -1,0 +1,73 @@
+/*
+===============================================================================
+
+ C header file for aeabi
+
+ Copyright (C) 2021-2023 agbabi contributors
+ For conditions of distribution and use, see copyright notice in LICENSE.md
+
+===============================================================================
+*/
+
+#ifndef AEABI_H
+#define AEABI_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+
+/**
+ * Alias of __aeabi_memcpy4
+ * @param dest Destination address
+ * @param src Source address
+ * @param n Number of bytes to copy
+ */
+void __aeabi_memcpy8(void* __restrict__ dest, const void* __restrict__ src, size_t n) __attribute__((nonnull(1, 2)));
+
+/**
+ * Copies n bytes from src to dest (forward)
+ * Assumes dest and src are 4-byte aligned
+ * @param dest Destination address
+ * @param src Source address
+ * @param n Number of bytes to copy
+ */
+void __aeabi_memcpy4(void* __restrict__ dest, const void* __restrict__ src, size_t n) __attribute__((nonnull(1, 2)));
+
+/**
+ * Copies n bytes from src to dest (forward)
+ * @param dest Destination address
+ * @param src Source address
+ * @param n Number of bytes to copy
+ */
+void __aeabi_memcpy(void* __restrict__ dest, const void* __restrict__ src, size_t n) __attribute__((nonnull(1, 2)));
+
+/**
+ * Alias of __aeabi_memmove4
+ * @param dest Destination address
+ * @param src Source address
+ * @param n Number of bytes to copy
+ */
+void __aeabi_memmove8(void* dest, const void* src, size_t n) __attribute__((nonnull(1, 2)));
+
+/**
+ * Safely copies n bytes of src to dest
+ * Assumes dest and src are 4-byte aligned
+ * @param dest Destination address
+ * @param src Source address
+ * @param n Number of bytes to copy
+ */
+void __aeabi_memmove4(void* dest, const void* src, size_t n) __attribute__((nonnull(1, 2)));
+
+/**
+ * Safely copies n bytes of src to dest
+ * @param dest Destination address
+ * @param src Source address
+ * @param n Number of bytes to copy
+ */
+void __aeabi_memmove(void* dest, const void* src, size_t n) __attribute__((nonnull(1, 2)));
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* define AEABI_H */

--- a/libs/libsysnds/include/ndsabi.h
+++ b/libs/libsysnds/include/ndsabi.h
@@ -1,0 +1,58 @@
+/*
+===============================================================================
+
+ C header file for ndsabi
+
+ Copyright (C) 2021-2023 agbabi contributors
+ For conditions of distribution and use, see copyright notice in LICENSE.md
+
+===============================================================================
+*/
+
+#ifndef NDSABI_H
+#define NDSABI_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h>
+
+/**
+ * Copies n bytes from src to dest (forward)
+ * Assumes dest and src are 2-byte aligned
+ * @param dest Destination address
+ * @param src Source address
+ * @param n Number of bytes to copy
+ */
+void __ndsabi_memcpy2(void* __restrict__ dest, const void* __restrict__ src, size_t n) __attribute__((nonnull(1, 2)));
+
+/**
+ * Copies n bytes from src to dest (forward)
+ * This is a slow, unaligned, byte-by-byte copy: ideal for SRAM
+ * @param dest Destination address
+ * @param src Source address
+ * @param n Number of bytes to copy
+ */
+void __ndsabi_memcpy1(void* __restrict__ dest, const void* __restrict__ src, size_t n) __attribute__((nonnull(1, 2)));
+
+/**
+ * Copies n bytes from src to dest (backwards)
+ * This is a slow, unaligned, byte-by-byte copy: ideal for SRAM
+ * @param dest Destination address
+ * @param src Source address
+ * @param n Number of bytes to copy
+ */
+void __ndsabi_rmemcpy1(void* __restrict__ dest, const void* __restrict__ src, size_t n) __attribute__((nonnull(1, 2)));
+
+/**
+ * Copies n bytes from src to dest (backwards)
+ * @param dest Destination address
+ * @param src Source address
+ * @param n Number of bytes to copy
+ */
+void __ndsabi_rmemcpy(void* __restrict__ dest, const void* __restrict__ src, size_t n) __attribute__((nonnull(1, 2)));
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* define NDSABI_H */

--- a/libs/libsysnds/include/ndsabi.h
+++ b/libs/libsysnds/include/ndsabi.h
@@ -52,6 +52,24 @@ void __ndsabi_rmemcpy1(void* __restrict__ dest, const void* __restrict__ src, si
  */
 void __ndsabi_rmemcpy(void* __restrict__ dest, const void* __restrict__ src, size_t n) __attribute__((nonnull(1, 2)));
 
+/**
+ * Copies n bytes in multiples of 16 bytes from src to dest (forward) using FIQ mode
+ * Assumes dest and src are 4-byte aligned
+ * @param dest Destination address
+ * @param src Source address
+ * @param n Number of bytes to copy, must be a multiple of 16
+ */
+void __ndsabi_fiq_memcpy4x4(void* __restrict__ dest, const void* __restrict__ src, size_t n) __attribute__((nonnull(1, 2)));
+
+/**
+ * Copies n bytes from src to dest (forward) using FIQ mode
+ * Assumes dest and src are 4-byte aligned
+ * @param dest Destination address
+ * @param src Source address
+ * @param n Number of bytes to copy
+ */
+void __ndsabi_fiq_memcpy4(void* __restrict__ dest, const void* __restrict__ src, size_t n) __attribute__((nonnull(1, 2)));
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/libsysnds/include/ndsabi.h
+++ b/libs/libsysnds/include/ndsabi.h
@@ -70,6 +70,26 @@ void __ndsabi_fiq_memcpy4x4(void* __restrict__ dest, const void* __restrict__ sr
  */
 void __ndsabi_fiq_memcpy4(void* __restrict__ dest, const void* __restrict__ src, size_t n) __attribute__((nonnull(1, 2)));
 
+/**
+ * Fills dest with n bytes of c
+ * Assumes dest is 4-byte aligned
+ * Trailing copy uses the low word of c, and the low byte of c
+ * @param dest Destination address
+ * @param n Number of bytes to set
+ * @param c Value to set
+ */
+void __ndsabi_lwordset4(void* dest, size_t n, long long c) __attribute__((nonnull(1)));
+
+/**
+ * Fills dest with n bytes of c
+ * Assumes dest is 4-byte aligned
+ * Trailing copy uses the low byte of c
+ * @param dest Destination address
+ * @param n Number of bytes to set
+ * @param c Value to set
+ */
+void __ndsabi_wordset4(void* dest, size_t n, int c) __attribute__((nonnull(1)));
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/libsysnds/source/common/ndsabi/LICENSE.md
+++ b/libs/libsysnds/source/common/ndsabi/LICENSE.md
@@ -1,0 +1,17 @@
+libagbabi is available under the [zlib license](https://www.zlib.net/zlib_license.html) :
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+   claim that you wrote the original software. If you use this software
+   in a product, an acknowledgment in the product documentation would be
+   appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.

--- a/libs/libsysnds/source/common/ndsabi/fiq_memcpy.s
+++ b/libs/libsysnds/source/common/ndsabi/fiq_memcpy.s
@@ -1,0 +1,97 @@
+@===============================================================================
+@
+@ Support:
+@    __ndsabi_fiq_memcpy4, __ndsabi_fiq_memcpy4x4
+@
+@ Copyright (C) 2021-2023 agbabi contributors
+@ For conditions of distribution and use, see copyright notice in LICENSE.md
+@
+@===============================================================================
+
+.include "macros.inc"
+
+    .arm
+    .align 2
+
+    .section .text.__ndsabi_fiq_memcpy4, "ax", %progbits
+    .global __ndsabi_fiq_memcpy4
+    .type __ndsabi_fiq_memcpy4, %function
+__ndsabi_fiq_memcpy4:
+    cmp     r2, #48
+    blt     .Lcopy_words
+
+    push    {r4-r7}
+    mrs     r3, cpsr
+
+    @ Enter FIQ mode
+    bic     r12, r3, #0x1f
+    orr     r12, #0x11
+    msr     cpsr, r12
+    msr     spsr, r3
+
+.Lloop_48:
+    subs    r2, r2, #48
+    ldmgeia r1!, {r3-r14}
+    stmgeia r0!, {r3-r14}
+    bgt     .Lloop_48
+
+    @ Exit FIQ mode
+    mrs     r3, spsr
+    msr     cpsr, r3
+    pop     {r4-r7}
+
+    adds    r2, r2, #48
+    bxeq    lr
+
+.Lcopy_words:
+    subs    r2, r2, #4
+    ldrge   r3, [r1], #4
+    strge   r3, [r0], #4
+    bgt     .Lcopy_words
+    bxeq    lr
+
+    @ Copy byte & half tail
+    joaobapt_test r2
+    @ Copy half
+    ldrcsh  r3, [r1], #2
+    strcsh  r3, [r0], #2
+    @ Copy byte
+    ldrmib  r3, [r1]
+    strmib  r3, [r0]
+    bx      lr
+
+    .section .text.__ndsabi_fiq_memcpy4x4, "ax", %progbits
+    .global __ndsabi_fiq_memcpy4x4
+    .type __ndsabi_fiq_memcpy4x4, %function
+__ndsabi_fiq_memcpy4x4:
+    push    {r4-r10}
+    cmp     r2, #48
+    blt     .Lcopy_tail_4x4
+
+    @ Enter FIQ mode
+    mrs     r3, cpsr
+    bic     r12, r3, #0x1f
+    orr     r12, #0x11
+    msr     cpsr, r12
+    msr     spsr, r3
+
+.Lloop_48_4x4:
+    subs    r2, r2, #48
+    ldmgeia r1!, {r3-r14}
+    stmgeia r0!, {r3-r14}
+    bgt     .Lloop_48_4x4
+
+    @ Exit FIQ mode
+    mrs     r3, spsr
+    msr     cpsr, r3
+
+.Lcopy_tail_4x4:
+    @ JoaoBapt test 48-bytes
+    joaobapt_test_lsl r2, #27
+    ldmcsia r1!, {r3-r10}
+    stmcsia r0!, {r3-r10}
+    ldmmiia r1!, {r3-r6}
+    stmmiia r0!, {r3-r6}
+
+    pop     {r4-r10}
+    bx      lr

--- a/libs/libsysnds/source/common/ndsabi/macros.inc
+++ b/libs/libsysnds/source/common/ndsabi/macros.inc
@@ -1,0 +1,41 @@
+@===============================================================================
+@
+@ ARM assembly support macros
+@
+@ Copyright (C) 2021-2023 agbabi contributors
+@ For conditions of distribution and use, see copyright notice in LICENSE.md
+@
+@===============================================================================
+
+@ Shift and test upper two bits, clobbering \reg
+@ Use mi for first bit, cs for second bit
+.macro joaobapt_test_lsl reg shift = #0
+    movs    \reg, \reg, lsl \shift
+.endm
+
+@ Test lowest two bits, clobbering \reg
+@ Use mi for low bit, cs for high bit
+.macro joaobapt_test reg
+    joaobapt_test_lsl \reg, #31
+.endm
+
+@ Test lowest two bits of \src, result stored in \dst
+@ Use mi for low bit, cs for high bit
+.macro joaobapt_test_into dst, src
+    movs    \dst, \src, lsl #31
+.endm
+
+@ Branches depending on lowest two bits, clobbering \reg
+@ b_mi = low bit case, b_cs = high bit case
+.macro joaobapt_switch reg, b_mi, b_cs
+    joaobapt_test \reg
+    bmi     \b_mi
+    bcs     \b_cs
+.endm
+
+@ Branches depending on alignment of \a and \b, clobbering \scratch
+@ b_byte = off-by-byte case, b_half = off-by-half case
+.macro align_switch a, b, scratch, b_byte, b_half
+    eor     \scratch, \a, \b
+    joaobapt_switch \scratch, \b_byte, \b_half
+.endm

--- a/libs/libsysnds/source/common/ndsabi/memcpy.s
+++ b/libs/libsysnds/source/common/ndsabi/memcpy.s
@@ -1,0 +1,128 @@
+@===============================================================================
+@
+@ ABI:
+@    __aeabi_memcpy, __aeabi_memcpy4, __aeabi_memcpy8
+@ Standard:
+@    memcpy
+@ Support:
+@    __ndsabi_memcpy2, __ndsabi_memcpy1
+@
+@ Copyright (C) 2021-2023 agbabi contributors
+@ For conditions of distribution and use, see copyright notice in LICENSE.md
+@
+@===============================================================================
+
+.include "macros.inc"
+
+    .arm
+    .align 2
+
+    .section .text.__aeabi_memcpy, "ax", %progbits
+    .global __aeabi_memcpy
+    .type __aeabi_memcpy, %function
+__aeabi_memcpy:
+    @ >6-bytes is roughly the threshold when byte-by-byte copy is slower
+    cmp     r2, #6
+    ble     __ndsabi_memcpy1
+
+    align_switch r0, r1, r3, __ndsabi_memcpy1, .Lcopy_halves
+
+    @ Check if r0 (or r1) needs word aligning
+    rsbs    r3, r0, #4
+    joaobapt_test r3
+
+    @ Copy byte head to align
+    ldrmib  r3, [r1], #1
+    strmib  r3, [r0], #1
+    submi   r2, r2, #1
+    @ r0, r1 are now half aligned
+
+    @ Copy half head to align
+    ldrcsh  r3, [r1], #2
+    strcsh  r3, [r0], #2
+    subcs   r2, r2, #2
+    @ r0, r1 are now word aligned
+
+    .global __aeabi_memcpy8
+    .type __aeabi_memcpy8, %function
+__aeabi_memcpy8:
+    .global __aeabi_memcpy4
+    .type __aeabi_memcpy4, %function
+__aeabi_memcpy4:
+    cmp     r2, #32
+    blt     .Lcopy_words
+
+    @ Word aligned, 32-byte copy
+    push    {r4-r10}
+.Lloop_32:
+    subs    r2, r2, #32
+    ldmgeia r1!, {r3-r10}
+    stmgeia r0!, {r3-r10}
+    bgt     .Lloop_32
+    pop     {r4-r10}
+    bxeq    lr
+
+    @ < 32 bytes remaining to be copied
+    add     r2, r2, #32
+
+.Lcopy_words:
+    cmp     r2, #4
+    blt     .Lcopy_halves
+.Lloop_4:
+    subs    r2, r2, #4
+    ldrge   r3, [r1], #4
+    strge   r3, [r0], #4
+    bgt     .Lloop_4
+    bxeq    lr
+
+    @ Copy byte & half tail
+    @ This test still works when r2 is negative
+    joaobapt_test r2
+    @ Copy half
+    ldrcsh  r3, [r1], #2
+    strcsh  r3, [r0], #2
+    @ Copy byte
+    ldrmib  r3, [r1]
+    strmib  r3, [r0]
+    bx      lr
+
+.Lcopy_halves:
+    @ Copy byte head to align
+    tst     r0, #1
+    ldrneb  r3, [r1], #1
+    strneb  r3, [r0], #1
+    subne   r2, r2, #1
+    @ r0, r1 are now half aligned
+
+    .global __ndsabi_memcpy2
+    .type __ndsabi_memcpy2, %function
+__ndsabi_memcpy2:
+    subs    r2, r2, #2
+    ldrgeh  r3, [r1], #2
+    strgeh  r3, [r0], #2
+    bgt     __ndsabi_memcpy2
+    bxeq    lr
+
+    @ Copy byte tail
+    adds    r2, r2, #2
+    ldrneb  r3, [r1]
+    strneb  r3, [r0]
+    bx      lr
+
+    .global __ndsabi_memcpy1
+    .type __ndsabi_memcpy1, %function
+__ndsabi_memcpy1:
+    subs    r2, r2, #1
+    ldrgeb  r3, [r1], #1
+    strgeb  r3, [r0], #1
+    bgt     __ndsabi_memcpy1
+    bx      lr
+
+    .section .text.memcpy, "ax", %progbits
+    .global memcpy
+    .type memcpy, %function
+memcpy:
+    push    {r0, lr}
+    bl      __aeabi_memcpy
+    pop     {r0, lr}
+    bx      lr

--- a/libs/libsysnds/source/common/ndsabi/memmove.s
+++ b/libs/libsysnds/source/common/ndsabi/memmove.s
@@ -1,0 +1,54 @@
+@===============================================================================
+@
+@ ABI:
+@    __aeabi_memmove, __aeabi_memmove4, __aeabi_memmove8
+@ Standard:
+@    memmove
+@
+@ Copyright (C) 2021-2023 agbabi contributors
+@ For conditions of distribution and use, see copyright notice in LICENSE.md
+@
+@===============================================================================
+
+    .arm
+    .align 2
+
+    .section .text.__aeabi_memmove, "ax", %progbits
+    .global __aeabi_memmove
+    .type __aeabi_memmove, %function
+__aeabi_memmove:
+    cmp     r0, r1
+    .extern __ndsabi_rmemcpy
+    bgt     __ndsabi_rmemcpy
+    .extern __aeabi_memcpy
+    b       __aeabi_memcpy
+
+    .global __aeabi_memmove8
+    .type __aeabi_memmove8, %function
+__aeabi_memmove8:
+    .global __aeabi_memmove4
+    .type __aeabi_memmove4, %function
+__aeabi_memmove4:
+    cmp     r0, r1
+    .extern __ndsabi_rmemcpy
+    bgt     __ndsabi_rmemcpy
+    .extern __aeabi_memcpy4
+    b       __aeabi_memcpy4
+
+    .global __ndsabi_memmove1
+    .type __ndsabi_memmove1, %function
+__ndsabi_memmove1:
+    cmp     r0, r1
+    .extern __ndsabi_rmemcpy1
+    bgt     __ndsabi_rmemcpy1
+    .extern __ndsabi_memcpy1
+    b       __ndsabi_memcpy1
+
+    .section .text.memmove, "ax", %progbits
+    .global memmove
+    .type memmove, %function
+memmove:
+    push    {r0, lr}
+    bl      __aeabi_memmove
+    pop     {r0, lr}
+    bx      lr

--- a/libs/libsysnds/source/common/ndsabi/memset.s
+++ b/libs/libsysnds/source/common/ndsabi/memset.s
@@ -1,0 +1,129 @@
+@===============================================================================
+@
+@ ABI:
+@    __aeabi_memclr, __aeabi_memclr4, __aeabi_memclr8,
+@    __aeabi_memset, __aeabi_memset4, __aeabi_memset8
+@ Standard:
+@    memset
+@ Support:
+@    __ndsabi_wordset4, __ndsabi_lwordset4, __ndsabi_memset1
+@
+@ Copyright (C) 2021-2023 agbabi contributors
+@ For conditions of distribution and use, see copyright notice in LICENSE.md
+@
+@===============================================================================
+
+.include "macros.inc"
+
+    .arm
+    .align 2
+
+    .section .text.__aeabi_memclr, "ax", %progbits
+    .global __aeabi_memclr
+    .type __aeabi_memclr, %function
+__aeabi_memclr:
+    mov     r2, #0
+    b       __aeabi_memset
+
+    .global __aeabi_memclr8
+    .type __aeabi_memclr8, %function
+__aeabi_memclr8:
+    .global __aeabi_memclr4
+    .type __aeabi_memclr4, %function
+__aeabi_memclr4:
+    mov     r2, #0
+    b       __ndsabi_wordset4
+
+    .section .text.__aeabi_memset, "ax", %progbits
+    .global __aeabi_memset
+    .type __aeabi_memset, %function
+__aeabi_memset:
+    @ < 8 bytes probably won't be aligned: go byte-by-byte
+    cmp     r1, #8
+    blt     __ndsabi_memset1
+
+    @ Copy head to align to next word
+    rsb     r3, r0, #4
+    joaobapt_test r3
+    strmib  r2, [r0], #1
+    submi   r1, r1, #1
+    strcsb  r2, [r0], #1
+    strcsb  r2, [r0], #1
+    subcs   r1, r1, #2
+
+    .global __aeabi_memset8
+    .type __aeabi_memset8, %function
+__aeabi_memset8:
+    .global __aeabi_memset4
+    .type __aeabi_memset4, %function
+__aeabi_memset4:
+    lsl     r2, r2, #24
+    orr     r2, r2, r2, lsr #8
+    orr     r2, r2, r2, lsr #16
+
+    .global __ndsabi_wordset4
+    .type __ndsabi_wordset4, %function
+__ndsabi_wordset4:
+    mov     r3, r2
+
+    .global __ndsabi_lwordset4
+    .type __ndsabi_lwordset4, %function
+__ndsabi_lwordset4:
+    @ 16 words is roughly the threshold when lwordset is slower
+    cmp     r1, #64
+    blt     .Lset_2_words
+
+    @ 8 word set
+    push    {r4-r9}
+    mov     r4, r2
+    mov     r5, r3
+    mov     r6, r2
+    mov     r7, r3
+    mov     r8, r2
+    mov     r9, r3
+
+.Lset_8_words:
+    subs    r1, r1, #32
+    stmgeia r0!, {r2-r9}
+    bgt     .Lset_8_words
+    pop     {r4-r9}
+    bxeq    lr
+
+    @ Fixup remaining
+    add     r1, r1, #32
+.Lset_2_words:
+    subs    r1, r1, #8
+    stmgeia r0!, {r2-r3}
+    bgt     .Lset_2_words
+    bxeq    lr
+
+    @ Test for remaining word
+    adds    r1, r1, #4
+    strge   r2, [r0], #4
+    bxeq    lr
+
+    @ Set tail
+    joaobapt_test r1
+    strcsh  r2, [r0], #2
+    strmib  r2, [r0], #1
+    bx      lr
+
+    .global __ndsabi_memset1
+    .type __ndsabi_memset, %function
+__ndsabi_memset1:
+    subs    r1, r1, #1
+    strgeb  r2, [r0], #1
+    bgt     __ndsabi_memset1
+    bx      lr
+
+    .section .text.memset, "ax", %progbits
+    .global memset
+    .type memset, %function
+memset:
+    mov     r3, r1
+    mov     r1, r2
+    mov     r2, r3
+    push    {r0, lr}
+    bl      __aeabi_memset
+    pop     {r0, lr}
+    bx      lr

--- a/libs/libsysnds/source/common/ndsabi/rmemcpy.s
+++ b/libs/libsysnds/source/common/ndsabi/rmemcpy.s
@@ -1,0 +1,106 @@
+@===============================================================================
+@
+@ Support:
+@    __ndsabi_rmemcpy, __ndsabi_rmemcpy1
+@
+@ Copyright (C) 2021-2023 agbabi contributors
+@ For conditions of distribution and use, see copyright notice in LICENSE.md
+@
+@===============================================================================
+
+.include "macros.inc"
+
+    .arm
+    .align 2
+
+    .section .text.__ndsabi_rmemcpy, "ax", %progbits
+    .global __ndsabi_rmemcpy
+    .type __ndsabi_rmemcpy, %function
+__ndsabi_rmemcpy:
+    @ >6-bytes is roughly the threshold when byte-by-byte copy is slower
+    cmp     r2, #6
+    ble     __ndsabi_rmemcpy1
+
+    align_switch r0, r1, r3, __ndsabi_rmemcpy1, .Lcopy_halves
+
+    @ Check if end needs word aligning
+    add     r3, r0, r2
+    joaobapt_test r3
+
+    @ Copy byte tail to align
+    submi   r2, r2, #1
+    ldrmib  r3, [r1, r2]
+    strmib  r3, [r0, r2]
+    @ r2 is now half aligned
+
+    @ Copy half tail to align
+    subcs   r2, r2, #2
+    ldrcsh  r3, [r1, r2]
+    strcsh  r3, [r0, r2]
+    @ r2 is now word aligned
+
+    cmp     r2, #32
+    blt     .Lcopy_words
+
+    @ Word aligned, 32-byte copy
+    push    {r0-r1, r4-r10}
+    add     r0, r0, r2
+    add     r1, r1, r2
+.Lloop_32:
+    subs    r2, r2, #32
+    ldmgedb r1!, {r3-r10}
+    stmgedb r0!, {r3-r10}
+    bgt     .Lloop_32
+    pop     {r0-r1, r4-r10}
+    bxeq    lr
+
+    @ < 32 bytes remaining to be copied
+    add     r2, r2, #32
+
+.Lcopy_words:
+    subs    r2, r2, #4
+    ldrge   r3, [r1, r2]
+    strge   r3, [r0, r2]
+    bgt     .Lcopy_words
+    bxeq    lr
+
+    @ Copy byte & half head
+    joaobapt_test_into r3, r2
+    @ Copy half
+    addcs   r2, r2, #2
+    ldrcsh  r3, [r1, r2]
+    strcsh  r3, [r0, r2]
+    @ Copy byte
+    ldrmib  r3, [r1]
+    strmib  r3, [r0]
+    bx      lr
+
+.Lcopy_halves:
+    @ Copy byte tail to align
+    add     r3, r0, r2
+    tst     r3, #1
+    subne   r2, r2, #1
+    ldrneb  r3, [r1, r2]
+    strneb  r3, [r0, r2]
+    @ r2 is now half aligned
+
+.Lloop_2:
+    subs    r2, r2, #2
+    ldrgeh  r3, [r1, r2]
+    strgeh  r3, [r0, r2]
+    bgt     .Lloop_2
+    bxeq    lr
+
+    @ Copy byte head
+    ldrb    r3, [r1]
+    strb    r3, [r0]
+    bx      lr
+
+    .global __ndsabi_rmemcpy1
+    .type __ndsabi_rmemcpy1, %function
+__ndsabi_rmemcpy1:
+    subs    r2, r2, #1
+    ldrgeb  r3, [r1, r2]
+    strgeb  r3, [r0, r2]
+    bgt     __ndsabi_rmemcpy1
+    bx      lr


### PR DESCRIPTION
These are derived from the zlib-licensed [agbabi project](https://github.com/felixjones/agbabi) (with adjustments to work correctly on an NDS-targetting toolchain with ARM/Thumb interwork), and have been extensively tested by myself to be both more performant than the newlib/picolibc defaults (which are written in C and not ARMv4-optimized), and correctly functioning.

There are other routines in agbabi, and I hope to see more of them provided upon verifying licensing and functionality. (I've ran into undiagnosed issues with using agbabi memset(), in particular.) Future work may also include checking if these routines can receive ARMv5-specific optimizations.