### PR TITLE
libc: disable picolib - sbrk is provided by libsysnds

### DIFF
--- a/libs/Makefile
+++ b/libs/Makefile
@@ -43,6 +43,7 @@ libc9:
 		--cross-file=../../cross-libc9.txt \
 		-Dmultilib=false \
 		-Dpicocrt=false \
+		-Dpicolib=false \
 		-Dsemihost=false \
 		-Dspecsdir=none \
 		-Dtests=false \
@@ -70,6 +71,7 @@ libc7:
 		--cross-file=../../cross-libc7.txt \
 		-Dmultilib=false \
 		-Dpicocrt=false \
+		-Dpicolib=false \
 		-Dsemihost=false \
 		-Dspecsdir=none \
 		-Dtests=false \


### PR DESCRIPTION
I got a duplicate `sbrk` symbol error when trying to build MegaZeux with BlocksDS; this fixes the issue. As picolib's responsibilities in general are either handled by libsysnds or not necessary/useful on the NDS target, this should be fine.