### PR TITLE
libsysnds: cache, diskio improvements

### DIFF
--- a/libs/libsysnds/source/arm9/fatfs/cache.c
+++ b/libs/libsysnds/source/arm9/fatfs/cache.c
@@ -82,6 +82,10 @@ void *cache_sector_add(uint8_t pdrv, uint32_t sector)
     // Cache full, evict one entry
     if (entry_found == 0)
     {
+        selected_entry++;
+        if (selected_entry >= cache_num_sectors)
+            selected_entry = 0;
+
         uint32_t min_usage_count = cache_entries[selected_entry].usage_count;
 
         if (min_usage_count > 1)

--- a/libs/libsysnds/source/arm9/fatfs/diskio.c
+++ b/libs/libsysnds/source/arm9/fatfs/diskio.c
@@ -316,7 +316,7 @@ DRESULT disk_read(BYTE pdrv, BYTE *buff, LBA_t sector, UINT count)
 // count:  Number of sectors to write
 DRESULT disk_write(BYTE pdrv, const BYTE *buff, LBA_t sector, UINT count)
 {
-    uint8_t align_buffer[FF_MAX_SS];
+    uint8_t *align_buffer;
     if (fs_initialized[pdrv] == 0)
         return RES_NOTRDY;
 
@@ -332,6 +332,10 @@ DRESULT disk_write(BYTE pdrv, const BYTE *buff, LBA_t sector, UINT count)
             if (((uint32_t) buff) & 0x03)
             {
                 // DLDI drivers expect a 4-byte aligned buffer.
+                align_buffer = malloc(FF_MAX_SS);
+                if (align_buffer == NULL)
+                    return RES_ERROR;
+
                 while (count > 0)
                 {
                     memcpy(align_buffer, buff, FF_MAX_SS);
@@ -342,6 +346,8 @@ DRESULT disk_write(BYTE pdrv, const BYTE *buff, LBA_t sector, UINT count)
                     sector++;
                     buff += FF_MAX_SS;
                 }
+
+                free(align_buffer);
             }
             else
             {

--- a/libs/libsysnds/source/arm9/fatfs/diskio.c
+++ b/libs/libsysnds/source/arm9/fatfs/diskio.c
@@ -234,8 +234,6 @@ DRESULT disk_read(BYTE pdrv, BYTE *buff, LBA_t sector, UINT count)
                 else
                 {
                     void *cache = cache_sector_add(pdrv, sector);
-                    if (cache == NULL)
-                        return RES_ERROR;
 
                     if (!io->readSectors(sector, 1, cache))
                         return RES_ERROR;
@@ -286,8 +284,6 @@ DRESULT disk_read(BYTE pdrv, BYTE *buff, LBA_t sector, UINT count)
                     else
                     {
                         void *cache = cache_sector_add(pdrv, sector);
-                        if (cache == NULL)
-                            return RES_ERROR;
 
                         cardRead(cache, offset, FF_MAX_SS);
 


### PR DESCRIPTION
* Speed up the cache eviction loop by bailing if a given cache entry is not used anymore. (This also might fix subtracting below 0, potentially causing an underflow. Should we be subtracting here, anyway? Directory entries could fall out of use quite quickly...)
* Use a round robin approach to eviction.
* Don't cache reads which are >1 sector and pointing to main RAM. These will only ever come from large (>1 sector) reads in FatFS, and as FatFS also caches one sector's worth of data, it is redundant to do so.
* Move cache invalidation to the DLDI handler itself - see matching libnds PR. It makes more sense to be there, IMO.
* Fix `disk_write` passing unaligned byte buffers to the DLDI device driver. This is not reliable across all DLDI drivers.