### PR TITLE
sys: initialize camera FIFO in default ARM7 implementation

### DIFF
--- a/sys/default_arm7/source/main.c
+++ b/sys/default_arm7/source/main.c
@@ -48,6 +48,8 @@ int main(int argc, char *argv[])
 
     installWifiFIFO();
     installSoundFIFO();
+    if (isDSiMode())
+        installCameraFIFO();
     installSystemFIFO(); // Sleep mode, storage, firmware...
 
     // Initialize Maxmod. It uses timer 0 internally.


### PR DESCRIPTION
Fixes https://github.com/blocksds/sdk/issues/117