### PR TITLE
sys, templates: specs file fixes

### DIFF
--- a/sys/crts/dldi_arm7.specs
+++ b/sys/crts/dldi_arm7.specs
@@ -13,7 +13,7 @@
 -fPIC %(blocksds_cc1)
 
 *cc1plus:
--fPIC %(blocksds_cc1plus)
+-fPIC %(cpp) %(blocksds_cc1plus)
 
 *cc1_cpu:
 -mcpu=arm7tdmi

--- a/sys/crts/dldi_arm9.specs
+++ b/sys/crts/dldi_arm9.specs
@@ -13,7 +13,7 @@
 -fPIC %(blocksds_cc1)
 
 *cc1plus:
--fPIC %(blocksds_cc1plus)
+-fPIC %(cpp) %(blocksds_cc1plus)
 
 *cc1_cpu:
 -mcpu=arm946e-s+nofp

--- a/sys/crts/ds_arm7.specs
+++ b/sys/crts/ds_arm7.specs
@@ -1,5 +1,6 @@
 %include <picolibc.specs>
 
+%rename cc1plus blocksds_cc1plus
 %rename cpp blocksds_cpp
 %rename link blocksds_link
 
@@ -8,6 +9,9 @@
 
 *cc1_cpu:
 -mcpu=arm7tdmi
+
+*cc1plus:
+%(cpp) %(blocksds_cc1plus)
 
 *link:
 %(blocksds_link) -T %:getenv(BLOCKSDS /sys/crts/ds_arm7.ld) --gc-sections --no-warn-rwx-segments

--- a/sys/crts/ds_arm7_iwram.specs
+++ b/sys/crts/ds_arm7_iwram.specs
@@ -1,5 +1,6 @@
 %include <picolibc.specs>
 
+%rename cc1plus blocksds_cc1plus
 %rename cpp blocksds_cpp
 %rename link blocksds_link
 
@@ -8,6 +9,9 @@
 
 *cc1_cpu:
 -mcpu=arm7tdmi
+
+*cc1plus:
+%(cpp) %(blocksds_cc1plus)
 
 *link:
 %(blocksds_link) -T %:getenv(BLOCKSDS /sys/crts/ds_arm7_iwram.ld) --gc-sections --no-warn-rwx-segments

--- a/sys/crts/ds_arm7_vram.specs
+++ b/sys/crts/ds_arm7_vram.specs
@@ -1,5 +1,6 @@
 %include <picolibc.specs>
 
+%rename cc1plus blocksds_cc1plus
 %rename cpp blocksds_cpp
 %rename link blocksds_link
 
@@ -8,6 +9,9 @@
 
 *cc1_cpu:
 -mcpu=arm7tdmi
+
+*cc1plus:
+%(cpp) %(blocksds_cc1plus)
 
 *link:
 %(blocksds_link) -T %:getenv(BLOCKSDS /sys/crts/ds_arm7_vram.ld) --gc-sections --no-warn-rwx-segments

--- a/sys/crts/ds_arm9.specs
+++ b/sys/crts/ds_arm9.specs
@@ -1,5 +1,6 @@
 %include <picolibc.specs>
 
+%rename cc1plus blocksds_cc1plus
 %rename cpp blocksds_cpp
 %rename link blocksds_link
 
@@ -8,6 +9,9 @@
 
 *cc1_cpu:
 -mcpu=arm946e-s+nofp
+
+*cc1plus:
+%(cpp) %(blocksds_cc1plus)
 
 *link:
 %(blocksds_link) -T %:getenv(BLOCKSDS /sys/crts/ds_arm9.mem) -T %:getenv(BLOCKSDS /sys/crts/ds_arm9.ld) --gc-sections --no-warn-rwx-segments --use-blx

--- a/sys/crts/dsi_arm9.specs
+++ b/sys/crts/dsi_arm9.specs
@@ -1,5 +1,6 @@
 %include <picolibc.specs>
 
+%rename cc1plus blocksds_cc1plus
 %rename cpp blocksds_cpp
 %rename link blocksds_link
 
@@ -8,6 +9,9 @@
 
 *cc1_cpu:
 -mcpu=arm946e-s+nofp
+
+*cc1plus:
+%(cpp) %(blocksds_cc1plus)
 
 *link:
 %(blocksds_link) -T %:getenv(BLOCKSDS /sys/crts/dsi_arm9.mem) -T %:getenv(BLOCKSDS /sys/crts/ds_arm9.ld) --gc-sections --no-warn-rwx-segments --use-blx

--- a/sys/default_arm7/Makefile
+++ b/sys/default_arm7/Makefile
@@ -67,6 +67,8 @@ SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
 # Compiler and linker flags
 # -------------------------
 
+ARCH		:= -mthumb -mcpu=arm7tdmi
+
 SPECS		:= $(BLOCKSDS)/sys/crts/ds_arm7.specs
 
 WARNFLAGS	:= -Wall
@@ -85,19 +87,19 @@ INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
 LIBDIRSFLAGS	:= $(foreach path,$(LIBDIRS),-L$(path)/lib)
 
 ASFLAGS		+= -x assembler-with-cpp $(INCLUDEFLAGS) \
-		   -mthumb -ffunction-sections -fdata-sections \
+		   $(ARCH) -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CFLAGS		+= -std=gnu11 $(WARNFLAGS) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -fno-exceptions -fno-rtti \
 		   -specs=$(SPECS)
 
-LDFLAGS		:= -mthumb $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
+LDFLAGS		:= $(ARCH) $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
 		   -Wl,--start-group $(LIBS) -Wl,--end-group -specs=$(SPECS)
 
 # Intermediate build files

--- a/sys/default_makefiles/rom_arm9/Makefile
+++ b/sys/default_makefiles/rom_arm9/Makefile
@@ -109,6 +109,8 @@ SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
 # Compiler and linker flags
 # -------------------------
 
+ARCH		:= -mthumb -mcpu=arm946e-s+nofp
+
 SPECS		:= $(BLOCKSDS)/sys/crts/ds_arm9.specs
 
 WARNFLAGS	:= -Wall
@@ -127,19 +129,19 @@ INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
 LIBDIRSFLAGS	:= $(foreach path,$(LIBDIRS),-L$(path)/lib)
 
 ASFLAGS		+= -x assembler-with-cpp $(INCLUDEFLAGS) \
-		   -mthumb -ffunction-sections -fdata-sections \
+		   $(ARCH) -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CFLAGS		+= -std=gnu11 $(WARNFLAGS) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -fno-exceptions -fno-rtti \
 		   -specs=$(SPECS)
 
-LDFLAGS		:= -mthumb $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
+LDFLAGS		:= $(ARCH) $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
 		   -Wl,--start-group $(LIBS) -Wl,--end-group -specs=$(SPECS)
 
 # Intermediate build files

--- a/sys/default_makefiles/rom_arm9arm7/Makefile.arm7
+++ b/sys/default_makefiles/rom_arm9arm7/Makefile.arm7
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: CC0-1.0
+n# SPDX-License-Identifier: CC0-1.0
 #
 # SPDX-FileContributor: Antonio Niño Díaz, 2023
 
@@ -69,6 +69,8 @@ SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
 # Compiler and linker flags
 # -------------------------
 
+ARCH		:= -mthumb -mcpu=arm7tdmi
+
 SPECS		:= $(BLOCKSDS)/sys/crts/ds_arm7.specs
 
 WARNFLAGS	:= -Wall
@@ -87,19 +89,19 @@ INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
 LIBDIRSFLAGS	:= $(foreach path,$(LIBDIRS),-L$(path)/lib)
 
 ASFLAGS		+= -x assembler-with-cpp $(INCLUDEFLAGS) \
-		   -mthumb -ffunction-sections -fdata-sections \
+		   $(ARCH) -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CFLAGS		+= -std=gnu11 $(WARNFLAGS) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -fno-exceptions -fno-rtti \
 		   -specs=$(SPECS)
 
-LDFLAGS		:= -mthumb $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
+LDFLAGS		:= $(ARCH) $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
 		   -Wl,--start-group $(LIBS) -Wl,--end-group -specs=$(SPECS)
 
 # Intermediate build files

--- a/sys/default_makefiles/rom_arm9arm7/Makefile.arm9
+++ b/sys/default_makefiles/rom_arm9arm7/Makefile.arm9
@@ -82,6 +82,8 @@ SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
 # Compiler and linker flags
 # -------------------------
 
+ARCH		:= -mthumb -mcpu=arm946e-s+nofp
+
 SPECS		:= $(BLOCKSDS)/sys/crts/ds_arm9.specs
 
 WARNFLAGS	:= -Wall
@@ -100,19 +102,19 @@ INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
 LIBDIRSFLAGS	:= $(foreach path,$(LIBDIRS),-L$(path)/lib)
 
 ASFLAGS		+= -x assembler-with-cpp $(INCLUDEFLAGS) \
-		   -mthumb -ffunction-sections -fdata-sections \
+		   $(ARCH) -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CFLAGS		+= -std=gnu11 $(WARNFLAGS) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -fno-exceptions -fno-rtti \
 		   -specs=$(SPECS)
 
-LDFLAGS		:= -mthumb $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
+LDFLAGS		:= $(ARCH) $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
 		   -Wl,--start-group $(LIBS) -Wl,--end-group -specs=$(SPECS)
 
 # Intermediate build files

--- a/sys/default_makefiles/rom_arm9arm7teak/Makefile.arm7
+++ b/sys/default_makefiles/rom_arm9arm7teak/Makefile.arm7
@@ -69,6 +69,8 @@ SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
 # Compiler and linker flags
 # -------------------------
 
+ARCH		:= -mthumb -mcpu=arm7tdmi
+
 SPECS		:= $(BLOCKSDS)/sys/crts/ds_arm7.specs
 
 WARNFLAGS	:= -Wall
@@ -87,19 +89,19 @@ INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
 LIBDIRSFLAGS	:= $(foreach path,$(LIBDIRS),-L$(path)/lib)
 
 ASFLAGS		+= -x assembler-with-cpp $(INCLUDEFLAGS) \
-		   -mthumb -ffunction-sections -fdata-sections \
+		   $(ARCH) -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CFLAGS		+= -std=gnu11 $(WARNFLAGS) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -fno-exceptions -fno-rtti \
 		   -specs=$(SPECS)
 
-LDFLAGS		:= -mthumb $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
+LDFLAGS		:= $(ARCH) $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
 		   -Wl,--start-group $(LIBS) -Wl,--end-group -specs=$(SPECS)
 
 # Intermediate build files

--- a/sys/default_makefiles/rom_arm9arm7teak/Makefile.arm9
+++ b/sys/default_makefiles/rom_arm9arm7teak/Makefile.arm9
@@ -82,6 +82,8 @@ SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
 # Compiler and linker flags
 # -------------------------
 
+ARCH		:= -mthumb -mcpu=arm946e-s+nofp
+
 SPECS		:= $(BLOCKSDS)/sys/crts/ds_arm9.specs
 
 WARNFLAGS	:= -Wall
@@ -100,19 +102,19 @@ INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
 LIBDIRSFLAGS	:= $(foreach path,$(LIBDIRS),-L$(path)/lib)
 
 ASFLAGS		+= -x assembler-with-cpp $(INCLUDEFLAGS) \
-		   -mthumb -ffunction-sections -fdata-sections \
+		   $(ARCH) -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CFLAGS		+= -std=gnu11 $(WARNFLAGS) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -fno-exceptions -fno-rtti \
 		   -specs=$(SPECS)
 
-LDFLAGS		:= -mthumb $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
+LDFLAGS		:= $(ARCH) $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
 		   -Wl,--start-group $(LIBS) -Wl,--end-group -specs=$(SPECS)
 
 # Intermediate build files

--- a/sys/default_makefiles/rom_arm9teak/Makefile.arm9
+++ b/sys/default_makefiles/rom_arm9teak/Makefile.arm9
@@ -82,6 +82,8 @@ SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
 # Compiler and linker flags
 # -------------------------
 
+ARCH		:= -mthumb -mcpu=arm946e-s+nofp
+
 SPECS		:= $(BLOCKSDS)/sys/crts/ds_arm9.specs
 
 WARNFLAGS	:= -Wall
@@ -100,19 +102,19 @@ INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
 LIBDIRSFLAGS	:= $(foreach path,$(LIBDIRS),-L$(path)/lib)
 
 ASFLAGS		+= -x assembler-with-cpp $(INCLUDEFLAGS) \
-		   -mthumb -ffunction-sections -fdata-sections \
+		   $(ARCH) -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CFLAGS		+= -std=gnu11 $(WARNFLAGS) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -fno-exceptions -fno-rtti \
 		   -specs=$(SPECS)
 
-LDFLAGS		:= -mthumb $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
+LDFLAGS		:= $(ARCH) $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
 		   -Wl,--start-group $(LIBS) -Wl,--end-group -specs=$(SPECS)
 
 # Intermediate build files

--- a/templates/dldi/Makefile
+++ b/templates/dldi/Makefile
@@ -80,8 +80,10 @@ SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
 # -------------------------
 
 ifeq ($(DLDI_ARM9),1)
+	ARCH	:= -mthumb -mcpu=arm946e-s+nofp
 	SPECS	:= $(BLOCKSDS)/sys/crts/dldi_arm9.specs
 else
+	ARCH	:= -mthumb -mcpu=arm7tdmi
 	SPECS	:= $(BLOCKSDS)/sys/crts/dldi_arm7.specs
 endif
 
@@ -101,19 +103,19 @@ INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
 LIBDIRSFLAGS	:= $(foreach path,$(LIBDIRS),-L$(path)/lib)
 
 ASFLAGS		+= -x assembler-with-cpp $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -ffunction-sections -fdata-sections \
+		   $(ARCH) -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CFLAGS		+= -std=gnu11 $(WARNFLAGS) $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS) $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -fno-exceptions -fno-rtti \
 		   -specs=$(SPECS)
 
-LDFLAGS		:= -mthumb $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
+LDFLAGS		:= $(ARCH) $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
 		   -Wl,--start-group $(LIBS) -Wl,--end-group -specs=$(SPECS)
 
 # Intermediate build files

--- a/templates/library_arm9_only/Makefile
+++ b/templates/library_arm9_only/Makefile
@@ -74,6 +74,8 @@ SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
 # Compiler and linker flags
 # -------------------------
 
+ARCH		:= -mthumb -mcpu=arm946e-s+nofp
+
 SPECS		:= $(BLOCKSDS)/sys/crts/ds_arm9.specs
 
 WARNFLAGS	:= -Wall
@@ -82,15 +84,15 @@ INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
 		   $(foreach path,$(LIBDIRS),-I$(path)/include)
 
 ASFLAGS		+= -x assembler-with-cpp $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -ffunction-sections -fdata-sections \
+		   $(ARCH) -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CFLAGS		+= -std=gnu11 $(WARNFLAGS) $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS) $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -fno-exceptions -fno-rtti \
 		   -specs=$(SPECS)
 

--- a/templates/library_combined/Makefile.arm7
+++ b/templates/library_combined/Makefile.arm7
@@ -60,6 +60,8 @@ SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
 # Compiler and linker flags
 # -------------------------
 
+ARCH		:= -mthumb -mcpu=arm7tdmi
+
 SPECS		:= $(BLOCKSDS)/sys/crts/ds_arm7.specs
 
 WARNFLAGS	:= -Wall
@@ -68,15 +70,15 @@ INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
 		   $(foreach path,$(LIBDIRS),-I$(path)/include)
 
 ASFLAGS		+= -x assembler-with-cpp $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -ffunction-sections -fdata-sections \
+		   $(ARCH) -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CFLAGS		+= -std=gnu11 $(WARNFLAGS) $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS) $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -fno-exceptions -fno-rtti \
 		   -specs=$(SPECS)
 

--- a/templates/library_combined/Makefile.arm9
+++ b/templates/library_combined/Makefile.arm9
@@ -71,6 +71,8 @@ SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
 # Compiler and linker flags
 # -------------------------
 
+ARCH		:= -mthumb -mcpu=arm946e-s+nofp
+
 SPECS		:= $(BLOCKSDS)/sys/crts/ds_arm9.specs
 
 WARNFLAGS	:= -Wall
@@ -79,15 +81,15 @@ INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
 		   $(foreach path,$(LIBDIRS),-I$(path)/include)
 
 ASFLAGS		+= -x assembler-with-cpp $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -ffunction-sections -fdata-sections \
+		   $(ARCH) -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CFLAGS		+= -std=gnu11 $(WARNFLAGS) $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS) $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -fno-exceptions -fno-rtti \
 		   -specs=$(SPECS)
 

--- a/templates/rom_arm9_only/Makefile
+++ b/templates/rom_arm9_only/Makefile
@@ -110,6 +110,8 @@ SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
 # Compiler and linker flags
 # -------------------------
 
+ARCH		:= -mthumb -mcpu=arm946e-s+nofp
+
 SPECS		:= $(BLOCKSDS)/sys/crts/ds_arm9.specs
 
 WARNFLAGS	:= -Wall
@@ -128,19 +130,19 @@ INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
 LIBDIRSFLAGS	:= $(foreach path,$(LIBDIRS),-L$(path)/lib)
 
 ASFLAGS		+= -x assembler-with-cpp $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -ffunction-sections -fdata-sections \
+		   $(ARCH) -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CFLAGS		+= -std=gnu11 $(WARNFLAGS) $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS) $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -fno-exceptions -fno-rtti \
 		   -specs=$(SPECS)
 
-LDFLAGS		:= -mthumb $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
+LDFLAGS		:= $(ARCH) $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
 		   -Wl,--start-group $(LIBS) -Wl,--end-group -specs=$(SPECS)
 
 # Intermediate build files

--- a/templates/rom_combined/Makefile.arm7
+++ b/templates/rom_combined/Makefile.arm7
@@ -71,6 +71,8 @@ SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
 # Compiler and linker flags
 # -------------------------
 
+ARCH		:= -mthumb -mcpu=arm7tdmi
+
 SPECS		:= $(BLOCKSDS)/sys/crts/ds_arm7.specs
 
 WARNFLAGS	:= -Wall
@@ -89,19 +91,19 @@ INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
 LIBDIRSFLAGS	:= $(foreach path,$(LIBDIRS),-L$(path)/lib)
 
 ASFLAGS		+= -x assembler-with-cpp $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -ffunction-sections -fdata-sections \
+		   $(ARCH) -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CFLAGS		+= -std=gnu11 $(WARNFLAGS) $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS) $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -fno-exceptions -fno-rtti \
 		   -specs=$(SPECS)
 
-LDFLAGS		:= -mthumb $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
+LDFLAGS		:= $(ARCH) $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
 		   -Wl,--start-group $(LIBS) -Wl,--end-group -specs=$(SPECS)
 
 # Intermediate build files

--- a/templates/rom_combined/Makefile.arm9
+++ b/templates/rom_combined/Makefile.arm9
@@ -83,6 +83,8 @@ SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
 # Compiler and linker flags
 # -------------------------
 
+ARCH		:= -mthumb -mcpu=arm946e-s+nofp
+
 SPECS		:= $(BLOCKSDS)/sys/crts/ds_arm9.specs
 
 WARNFLAGS	:= -Wall
@@ -101,19 +103,19 @@ INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
 LIBDIRSFLAGS	:= $(foreach path,$(LIBDIRS),-L$(path)/lib)
 
 ASFLAGS		+= -x assembler-with-cpp $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -ffunction-sections -fdata-sections \
+		   $(ARCH) -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CFLAGS		+= -std=gnu11 $(WARNFLAGS) $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -specs=$(SPECS)
 
 CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS) $(DEFINES) $(INCLUDEFLAGS) \
-		   -mthumb -O2 -ffunction-sections -fdata-sections \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
 		   -fno-exceptions -fno-rtti \
 		   -specs=$(SPECS)
 
-LDFLAGS		:= -mthumb $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
+LDFLAGS		:= $(ARCH) $(LIBDIRSFLAGS) -Wl,-Map,$(MAP) $(DEFINES) \
 		   -Wl,--start-group $(LIBS) -Wl,--end-group -specs=$(SPECS)
 
 # Intermediate build files


### PR DESCRIPTION
Unfortunately, the C++ driver doesn't use all the fields that the C driver does. In particular:

* `cpp` is ignored - but we can patch around this in the specs file.
* `cc1_cpu` is ignored - unfortunately, we cannot patch around this in the specs file, so I needed to bring back `mcpu` into the Makefiles.