### PR TITLE
templates: use build/$(NAME) for build directory

### DIFF
--- a/sys/default_makefiles/rom_arm9/Makefile
+++ b/sys/default_makefiles/rom_arm9/Makefile
@@ -51,7 +51,7 @@ LIBDIRS		+= $(BLOCKSDS)/libs/libnds
 # Build artifacts
 # ---------------
 
-BUILDDIR	:= build
+BUILDDIR	:= build/$(NAME)
 ELF		:= build/$(NAME).elf
 DUMP		:= build/$(NAME).dump
 MAP		:= build/$(NAME).map

--- a/sys/default_makefiles/rom_arm9arm7/Makefile.arm7
+++ b/sys/default_makefiles/rom_arm9arm7/Makefile.arm7
@@ -29,8 +29,8 @@ LIBDIRS		+= $(BLOCKSDS)/libs/libnds
 # Build artifacts
 # -----------------
 
-BUILDDIR	:= build/arm7
 NAME		:= arm7
+BUILDDIR	:= build/$(NAME)
 ELF		:= build/$(NAME).elf
 DUMP		:= build/$(NAME).dump
 MAP		:= build/$(NAME).map

--- a/sys/default_makefiles/rom_arm9arm7/Makefile.arm9
+++ b/sys/default_makefiles/rom_arm9arm7/Makefile.arm9
@@ -31,8 +31,8 @@ LIBDIRS		+= $(BLOCKSDS)/libs/libnds
 # Build artifacts
 # ---------------
 
-BUILDDIR	:= build/arm9
 NAME		:= arm9
+BUILDDIR	:= build/$(NAME)
 ELF		:= build/$(NAME).elf
 DUMP		:= build/$(NAME).dump
 MAP		:= build/$(NAME).map

--- a/sys/default_makefiles/rom_arm9arm7teak/Makefile.arm7
+++ b/sys/default_makefiles/rom_arm9arm7teak/Makefile.arm7
@@ -29,8 +29,8 @@ LIBDIRS		+= $(BLOCKSDS)/libs/libnds
 # Build artifacts
 # -----------------
 
-BUILDDIR	:= build/arm7
 NAME		:= arm7
+BUILDDIR	:= build/$(NAME)
 ELF		:= build/$(NAME).elf
 DUMP		:= build/$(NAME).dump
 MAP		:= build/$(NAME).map

--- a/sys/default_makefiles/rom_arm9arm7teak/Makefile.arm9
+++ b/sys/default_makefiles/rom_arm9arm7teak/Makefile.arm9
@@ -31,8 +31,8 @@ LIBDIRS		+= $(BLOCKSDS)/libs/libnds
 # Build artifacts
 # ---------------
 
-BUILDDIR	:= build/arm9
 NAME		:= arm9
+BUILDDIR	:= build/$(NAME)
 ELF		:= build/$(NAME).elf
 DUMP		:= build/$(NAME).dump
 MAP		:= build/$(NAME).map

--- a/sys/default_makefiles/rom_arm9arm7teak/Makefile.teak
+++ b/sys/default_makefiles/rom_arm9arm7teak/Makefile.teak
@@ -29,8 +29,8 @@ LIBDIRS		+= $(BLOCKSDS)/libs/libteak
 # Build artifacts
 # ---------------
 
-BUILDDIR	:= build/teak
 NAME		:= teak
+BUILDDIR	:= build/$(NAME)
 ELF		:= build/$(NAME).elf
 TLF		:= build/$(NAME).tlf
 DUMP		:= build/$(NAME).dump

--- a/sys/default_makefiles/rom_arm9teak/Makefile.arm9
+++ b/sys/default_makefiles/rom_arm9teak/Makefile.arm9
@@ -31,8 +31,8 @@ LIBDIRS		+= $(BLOCKSDS)/libs/libnds
 # Build artifacts
 # ---------------
 
-BUILDDIR	:= build/arm9
 NAME		:= arm9
+BUILDDIR	:= build/$(NAME)
 ELF		:= build/$(NAME).elf
 DUMP		:= build/$(NAME).dump
 MAP		:= build/$(NAME).map

--- a/sys/default_makefiles/rom_arm9teak/Makefile.teak
+++ b/sys/default_makefiles/rom_arm9teak/Makefile.teak
@@ -29,8 +29,8 @@ LIBDIRS		+= $(BLOCKSDS)/libs/libteak
 # Build artifacts
 # ---------------
 
-BUILDDIR	:= build/teak
 NAME		:= teak
+BUILDDIR	:= build/$(NAME)
 ELF		:= build/$(NAME).elf
 TLF		:= build/$(NAME).tlf
 DUMP		:= build/$(NAME).dump

--- a/templates/dldi/Makefile
+++ b/templates/dldi/Makefile
@@ -38,7 +38,7 @@ LIBDIRS		:= $(BLOCKSDS)/libs/libnds
 # Build artifacts
 # -----------------
 
-BUILDDIR	:= build/
+BUILDDIR	:= build/$(NAME)
 ELF		:= build/$(NAME).elf
 DUMP		:= build/$(NAME).dump
 MAP		:= build/$(NAME).map

--- a/templates/library_arm9_only/Makefile
+++ b/templates/library_arm9_only/Makefile
@@ -31,7 +31,7 @@ LIBDIRS		:=
 
 NAME		:= test
 INSTALLNAME	:= library_arm9_only
-BUILDDIR	:= build
+BUILDDIR	:= build/$(NAME)
 ARCHIVE		:= lib/lib$(NAME).a
 
 # Tools

--- a/templates/library_combined/Makefile.arm7
+++ b/templates/library_combined/Makefile.arm7
@@ -28,7 +28,7 @@ LIBDIRS		:=
 # ---------------
 
 NAME		:= test7
-BUILDDIR	:= build/arm7
+BUILDDIR	:= build/$(NAME)
 ARCHIVE		:= lib/lib$(NAME).a
 
 # Tools

--- a/templates/library_combined/Makefile.arm9
+++ b/templates/library_combined/Makefile.arm9
@@ -30,7 +30,7 @@ LIBDIRS		:=
 # ---------------
 
 NAME		:= test9
-BUILDDIR	:= build/arm9
+BUILDDIR	:= build/$(NAME)
 ARCHIVE		:= lib/lib$(NAME).a
 
 # Tools

--- a/templates/rom_arm9_only/Makefile
+++ b/templates/rom_arm9_only/Makefile
@@ -52,7 +52,7 @@ LIBDIRS		:= $(BLOCKSDS)/libs/maxmod \
 # Build artifacts
 # ---------------
 
-BUILDDIR	:= build
+BUILDDIR	:= build/$(NAME)
 ELF		:= build/$(NAME).elf
 DUMP		:= build/$(NAME).dump
 MAP		:= build/$(NAME).map

--- a/templates/rom_combined/Makefile.arm7
+++ b/templates/rom_combined/Makefile.arm7
@@ -31,8 +31,8 @@ LIBDIRS		:= $(BLOCKSDS)/libs/libnds \
 # Build artifacts
 # -----------------
 
-BUILDDIR	:= build/arm7
 NAME		:= arm7
+BUILDDIR	:= build/$(NAME)
 ELF		:= build/$(NAME).elf
 DUMP		:= build/$(NAME).dump
 MAP		:= build/$(NAME).map

--- a/templates/rom_combined/Makefile.arm9
+++ b/templates/rom_combined/Makefile.arm9
@@ -32,8 +32,8 @@ LIBDIRS		:= $(BLOCKSDS)/libs/maxmod \
 # Build artifacts
 # ---------------
 
-BUILDDIR	:= build/arm9
 NAME		:= arm9
+BUILDDIR	:= build/$(NAME)
 ELF		:= build/$(NAME).elf
 DUMP		:= build/$(NAME).dump
 MAP		:= build/$(NAME).map


### PR DESCRIPTION
This allows flexibility in the event a user needs to build multiple binaries from the same source code. For example, if one needs builds with a specific DEFINE, and another without such a DEFINE, just a NAME change will make sure these do not conflict, while also making it relatively easy for a user to see which build directory is related to which Makefile.

Test: compile

You can find an example at https://github.com/lifehackerhansol/flashcard-bootstrap, where this logic is applied for the ARM9 binaries.
