### PR TITLE
devkitarm_porting_guide: note relative paths outside PWD is not supported

### DIFF
--- a/docs/content/technical/devkitarm_porting_guide.md
+++ b/docs/content/technical/devkitarm_porting_guide.md
@@ -48,9 +48,13 @@ AUDIODIRS   := audio
 NITROFSDIR  := nitrofs
 ```
 
-Important note: `SOURCEDIRS` searches all directories recursively. If you don't
+Important notes:
+
+- `SOURCEDIRS` searches all directories recursively. If you don't
 like this behaviour, go to the `SOURCES_S`, `SOURCES_C` and `SOURCES_CPP` lines
 and add `-maxdepth 1` to the `find` command.
+- Paths to directories that are outside of the root of the project is not 
+supported.
 
 Note that `TARGET` is not part of this group. The top of the Makefile has this
 other group of variables that you can also set to your own values:


### PR DESCRIPTION
For select "advanced" projects, such as a port of a source code that was not designed with devkitARM in mind, it is common practice to have a "platform" Makefile in a subdirectory that calls directories that are out of the scope of said Makefile's PWD.

This behaviour is unsupported in BlocksDS at this time. It should be noted.