### PR TITLE
examples: fix exception_handler undefined behaviour being detected by…

### DIFF
--- a/examples/debug/exception_handler/source/main.c
+++ b/examples/debug/exception_handler/source/main.c
@@ -25,8 +25,9 @@ int main(int argc, char **argv)
             break;
     }
 
-    // Write data to NULL to cause an exception
-    *(uint32_t *)NULL = 0xDEAD;
+    // Write data to an unmapped address to cause an exception
+    // (The compiler can detect NULL being used here)
+    *(uint32_t *)(0x00004000) = 0xDEAD;
 
     printf("Exception handling failed!\n");
     printf("Is this in an emulator?\n");


### PR DESCRIPTION
… GCC and optimized out

At times, GCC can detect obviously undefined behaviour and replace it with an undefined instruction.