### PR TITLE
Remove usage of __DATE__

### DIFF
--- a/tools/teaktool/source/main.c
+++ b/tools/teaktool/source/main.c
@@ -25,7 +25,7 @@ typedef struct {
 
 int main(int argc, char *argv[])
 {
-    printf("Teak tool " PACKAGE_VERSION " - %s\n", __DATE__);
+    printf("Teak tool " PACKAGE_VERSION "\n");
 
     const char *in_file = NULL;
     const char *out_file = NULL;


### PR DESCRIPTION
C's `__DATE__` prevents reproducible builds[[1](https://blog.llvm.org/2019/11/deterministic-builds-with-clang-and-lld.html)]; some LLVM frontends enforce build reproducibility (e.g. Zig) and so this does not compile. 

`__DATE__` is also present in ndstool