### PR TITLE
default_makefiles: Make SD root configurable

### DIFF
--- a/sys/default_makefiles/rom_arm9/Makefile
+++ b/sys/default_makefiles/rom_arm9/Makefile
@@ -22,9 +22,9 @@ GAME_ICON	?= $(BLOCKSDS)/sys/icon.bmp
 # --------------------------------
 
 # Root folder of the SD image
-SDROOT		:= sdroot
+SDROOT		?= sdroot
 # Name of the generated image it "DSi-1.sd" for no$gba in DSi mode
-SDIMAGE		:= image.bin
+SDIMAGE		?= image.bin
 
 # Source code paths
 # -----------------

--- a/sys/default_makefiles/rom_arm9arm7/Makefile
+++ b/sys/default_makefiles/rom_arm9arm7/Makefile
@@ -19,9 +19,9 @@ GAME_ICON	?= $(BLOCKSDS)/sys/icon.bmp
 # --------------------------------
 
 # Root folder of the SD image
-SDROOT		:= sdroot
+SDROOT		?= sdroot
 # Name of the generated image it "DSi-1.sd" for no$gba in DSi mode
-SDIMAGE		:= image.bin
+SDIMAGE		?= image.bin
 
 # Source code paths
 # -----------------

--- a/sys/default_makefiles/rom_arm9arm7teak/Makefile
+++ b/sys/default_makefiles/rom_arm9arm7teak/Makefile
@@ -19,9 +19,9 @@ GAME_ICON	?= $(BLOCKSDS)/sys/icon.bmp
 # --------------------------------
 
 # Root folder of the SD image
-SDROOT		:= sdroot
+SDROOT		?= sdroot
 # Name of the generated image it "DSi-1.sd" for no$gba in DSi mode
-SDIMAGE		:= image.bin
+SDIMAGE		?= image.bin
 
 # Source code paths
 # -----------------

--- a/sys/default_makefiles/rom_arm9teak/Makefile
+++ b/sys/default_makefiles/rom_arm9teak/Makefile
@@ -19,9 +19,9 @@ GAME_ICON	?= $(BLOCKSDS)/sys/icon.bmp
 # --------------------------------
 
 # Root folder of the SD image
-SDROOT		:= sdroot
+SDROOT		?= sdroot
 # Name of the generated image it "DSi-1.sd" for no$gba in DSi mode
-SDIMAGE		:= image.bin
+SDIMAGE		?= image.bin
 
 # Source code paths
 # -----------------


### PR DESCRIPTION
(don't overwrite sdroot or sdimage if already defined in default makefiles)