### PR TITLE
sys/crts: linkscript/crt0 upgrades

### DIFF
--- a/sys/crts/dldi.ld
+++ b/sys/crts/dldi.ld
@@ -149,7 +149,7 @@ SECTIONS
         __bss_start__ = ABSOLUTE(.);
         *(.dynbss)
         *(.gnu.linkonce.b*)
-        *(.bss* .gnu.linkonce.b*)
+        *(.bss*)
         *(COMMON)
         /* Place .noinit symbols in BSS for DLDI. */
         /* This is so that they're covered by the DLDI header's reserved BSS area. */

--- a/sys/crts/dldi.ld
+++ b/sys/crts/dldi.ld
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright (C) 2014-2024 Free Software Foundation, Inc.
+   Copying and distribution of this script, with or without modification,
+   are permitted in any medium without royalty provided the copyright
+   notice and this notice are preserved.  */
+
+/* SPDX-License-Identifier: MPL-2.0 AND FSFAP */
 
 OUTPUT_FORMAT("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
 OUTPUT_ARCH(arm)
@@ -113,11 +118,9 @@ SECTIONS
 
     .gcc_except_table :
     {
-        *(.gcc_except_table)
+        *(.gcc_except_table .gcc_except_table.*)
         . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
     } >ddmem = 0xff
-
-    .jcr : { KEEP (*(.jcr)) } >ddmem = 0
 
     __got_start = .;
     .got :
@@ -146,8 +149,11 @@ SECTIONS
         __bss_start__ = ABSOLUTE(.);
         *(.dynbss)
         *(.gnu.linkonce.b*)
-        *(.bss*)
+        *(.bss* .gnu.linkonce.b*)
         *(COMMON)
+        /* Place .noinit symbols in BSS for DLDI. */
+        /* This is so that they're covered by the DLDI header's reserved BSS area. */
+        *(.noinit .noinit.* .gnu.linkonce.n.*)
         . = ALIGN(4); /* REQUIRED. LD is flaky without it. */
     } >ddmem
 
@@ -163,40 +169,52 @@ SECTIONS
     PROVIDE (__dldi_header_driver_size = LOG2CEIL(ABSOLUTE(__bss_end) - ABSOLUTE(__text_start)));
 
     /* Stabs debugging sections.  */
-    .stab 0 : { *(.stab) }
-    .stabstr 0 : { *(.stabstr) }
-    .stab.excl 0 : { *(.stab.excl) }
-    .stab.exclstr 0 : { *(.stab.exclstr) }
-    .stab.index 0 : { *(.stab.index) }
+    .stab          0 : { *(.stab) }
+    .stabstr       0 : { *(.stabstr) }
+    .stab.excl     0 : { *(.stab.excl) }
+    .stab.exclstr  0 : { *(.stab.exclstr) }
+    .stab.index    0 : { *(.stab.index) }
     .stab.indexstr 0 : { *(.stab.indexstr) }
-    .comment 0 : { *(.comment) }
-    /*
-     * DWARF debug sections.
-     * Symbols in the DWARF debugging sections are relative to the beginning of
-     * the section so we begin them at 0.
-     */
-    /* DWARF 1 */
+    .comment 0 (INFO) : { *(.comment); LINKER_VERSION; }
+    .gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+    /* DWARF debug sections.
+       Symbols in the DWARF debugging sections are relative to the beginning
+       of the section so we begin them at 0.  */
+    /* DWARF 1.  */
     .debug          0 : { *(.debug) }
     .line           0 : { *(.line) }
-    /* GNU DWARF 1 extensions */
+    /* GNU DWARF 1 extensions.  */
     .debug_srcinfo  0 : { *(.debug_srcinfo) }
     .debug_sfnames  0 : { *(.debug_sfnames) }
-    /* DWARF 1.1 and DWARF 2 */
+    /* DWARF 1.1 and DWARF 2.  */
     .debug_aranges  0 : { *(.debug_aranges) }
     .debug_pubnames 0 : { *(.debug_pubnames) }
-    /* DWARF 2 */
-    .debug_info     0 : { *(.debug_info) }
+    /* DWARF 2.  */
+    .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
     .debug_abbrev   0 : { *(.debug_abbrev) }
-    .debug_line     0 : { *(.debug_line) }
+    .debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
     .debug_frame    0 : { *(.debug_frame) }
     .debug_str      0 : { *(.debug_str) }
     .debug_loc      0 : { *(.debug_loc) }
     .debug_macinfo  0 : { *(.debug_macinfo) }
-    /* SGI/MIPS DWARF 2 extensions */
+    /* SGI/MIPS DWARF 2 extensions.  */
     .debug_weaknames 0 : { *(.debug_weaknames) }
     .debug_funcnames 0 : { *(.debug_funcnames) }
     .debug_typenames 0 : { *(.debug_typenames) }
     .debug_varnames  0 : { *(.debug_varnames) }
-    .stack 0x80000 : { _stack = .; *(.stack) }
-    /* These must appear regardless of  .  */
+    /* DWARF 3.  */
+    .debug_pubtypes 0 : { *(.debug_pubtypes) }
+    .debug_ranges   0 : { *(.debug_ranges) }
+    /* DWARF 5.  */
+    .debug_addr     0 : { *(.debug_addr) }
+    .debug_line_str 0 : { *(.debug_line_str) }
+    .debug_loclists 0 : { *(.debug_loclists) }
+    .debug_macro    0 : { *(.debug_macro) }
+    .debug_names    0 : { *(.debug_names) }
+    .debug_rnglists 0 : { *(.debug_rnglists) }
+    .debug_str_offsets 0 : { *(.debug_str_offsets) }
+    .debug_sup      0 : { *(.debug_sup) }
+    .ARM.attributes 0 : { KEEP (*(.ARM.attributes)) KEEP (*(.gnu.attributes)) }
+    .note.gnu.arm.ident 0 : { KEEP (*(.note.gnu.arm.ident)) }
+    /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) }
 }

--- a/sys/crts/ds_arm7.ld
+++ b/sys/crts/ds_arm7.ld
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright (C) 2014-2024 Free Software Foundation, Inc.
+   Copying and distribution of this script, with or without modification,
+   are permitted in any medium without royalty provided the copyright
+   notice and this notice are preserved.  */
+
+/* SPDX-License-Identifier: MPL-2.0 AND FSFAP */
 
 OUTPUT_FORMAT("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
 OUTPUT_ARCH(arm)
@@ -6,30 +11,36 @@ ENTRY(_start)
 
 /* User-configurable symbols. */
 
+/* The size, in bytes, of the amount of shared WRAM used by ARM7 code. */
+/* Only 0 and 32768 are valid values. */
+PROVIDE(__shared_wram_size = 32768);
+ASSERT(__shared_wram_size == 0 || __shared_wram_size == 32768, "ARM7 shared WRAM size must be 0 KB or 32 KB");
+
 /* The size, in bytes, of the reserved section at the end of IWRAM. */
 /* Traditionally, ARM7 reserves 0x40 bytes here. */
 PROVIDE(__iwram_reserved_size = 0x40);
+ASSERT((__iwram_reserved_size & 3) == 0, "__iwram_reserved_size must be a multiple of 4");
 
 /* ARM supervisor (SWI calls) stack size. */
 PROVIDE(__svc_stack_size = 0x100);
+ASSERT((__svc_stack_size & 3) == 0, "__svc_stack_size must be a multiple of 4");
 
 /* ARM interrupt handler stack size. */
 PROVIDE(__irq_stack_size = 0x100);
+ASSERT((__irq_stack_size & 3) == 0, "__irq_stack_size must be a multiple of 4");
 
 PHDRS {
-	crt0  PT_LOAD FLAGS(7);
-	arm7  PT_LOAD FLAGS(7);
-	arm7i PT_LOAD FLAGS(0x100007);
+    crt0  PT_LOAD FLAGS(7);
+    arm7  PT_LOAD FLAGS(7);
+    arm7i PT_LOAD FLAGS(0x100007);
 }
 
-
 MEMORY {
-	ewram  : ORIGIN = 0x02380000, LENGTH = 12M - 512K
-	rom    : ORIGIN = 0x08000000, LENGTH = 32M
-	iwram  : ORIGIN = 0x037f8000, LENGTH = 96K
+    ewram : ORIGIN = 0x02380000, LENGTH = 12M - 512K
+    iwram : ORIGIN = 0x03800000 - __shared_wram_size, LENGTH = 65536 + __shared_wram_size	
 
-	twl_ewram : ORIGIN = 0x02e80000, LENGTH = 512K - 64K
-	twl_iwram : ORIGIN = 0x03000000, LENGTH = 256K
+    twl_ewram : ORIGIN = 0x02e80000, LENGTH = 512K - 64K
+    twl_iwram : ORIGIN = 0x03000000, LENGTH = 256K
 }
 
 __iwram_start	=	ORIGIN(iwram);
@@ -46,231 +57,283 @@ __irq_vector	=	0x04000000 - 4;
 SECTIONS
 {
 
-	.twl :
-	{
-		__arm7i_lma__ = LOADADDR(.twl);
-		__arm7i_start__ = .;
-		*(.twl)
-		*(.twl.text .twl.text.*)
-		*(.twl.rodata .twl.rodata.*)
-		*(.twl.data .twl.data.*)
-		*.twl*(.text .stub .text.* .gnu.linkonce.t.*)
-		*.twl*(.rodata)
-		*.twl*(.roda)
-		*.twl*(.rodata.*)
-		*.twl*(.data)
-		*.twl*(.data.*)
-		*.twl*(.gnu.linkonce.d*)
-		. = ALIGN(4);
-		__arm7i_end__ = .;
-	} >twl_iwram AT>twl_ewram :arm7i
+    .twl :
+    {
+        __arm7i_lma__ = LOADADDR(.twl);
+        __arm7i_start__ = .;
+        *(.twl)
+        *(.twl.text .twl.text.*)
+        *(.twl.rodata .twl.rodata.*)
+        *(.twl.data .twl.data.*)
+        *.twl*(.text .stub .text.* .gnu.linkonce.t.*)
+        *.twl*(.rodata)
+        *.twl*(.roda)
+        *.twl*(.rodata.*)
+        *.twl*(.data)
+        *.twl*(.data.*)
+        *.twl*(.gnu.linkonce.d*)
+        . = ALIGN(4);
+        __arm7i_end__ = .;
+    } >twl_iwram AT>twl_ewram :arm7i
 
-	.twl_bss ALIGN(4) (NOLOAD) :
-	{
-		__twl_bss_start__ = .;
-		*(.twl_bss .twl_bss.*)
-		*(.twl.bss .twl.bss.*)
-		*.twl.*(.dynbss)
-		*.twl.*(.gnu.linkonce.b*)
-		*.twl.*(.bss*)
-		*.twl.*(COMMON)
-		. = ALIGN(4);
-		__twl_bss_end__ = .;
-	} >twl_iwram :NONE
+    .twl_bss ALIGN(4) (NOLOAD) :
+    {
+        __twl_bss_start__ = .;
+        *(.twl_bss .twl_bss.*)
+        *(.twl.bss .twl.bss.*)
+        *.twl.*(.dynbss)
+        *.twl.*(.gnu.linkonce.b*)
+        *.twl.*(.bss*)
+        *.twl.*(COMMON)
+        . = ALIGN(4);
+        __twl_bss_end__ = .;
+    } >twl_iwram :NONE
 
-	.crt0	:
-	{
-		KEEP (*(.crt0))
-		. = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
-	} >ewram :crt0
+    .twl_noinit ALIGN(4) (NOLOAD):
+    {
+        __twl_noinit_start__ = ABSOLUTE(.);
+        *(.twl_noinit .twl_noinit.*)
+        *(.twl.noinit .twl.noinit.*)
+        *.twl*(.noinit)
+        *.twl*(.noinit.*)
+        *.twl*(.gnu.linkonce.n.*)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+        __twl_noinit_end__ = ABSOLUTE(.);
+        __twl_end__ = ABSOLUTE(.);
+    } >twl_iwram :NONE
 
-	.text :
-	{
-		__arm7_lma__ = LOADADDR(.text);
-		__arm7_start__ = .;
-		KEEP (*(SORT_NONE(.init)))
-		*(.plt)
-		*(.text .stub .text.* .gnu.linkonce.t.*)
-		KEEP (*(.text.*personality*))
-		/* .gnu.warning sections are handled specially by elf32.em.  */
-		*(.gnu.warning)
-		*(.glue_7t) *(.glue_7) *(.vfp11_veneer)
-		. = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
-	} >iwram AT>ewram :arm7
+    .crt0	:
+    {
+        KEEP (*(.crt0))
+        . = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
+    } >ewram :crt0
 
-	.fini           :
-	{
-		KEEP (*(.fini))
-	} >iwram AT>ewram
+    .text :
+    {
+        __arm7_lma__ = LOADADDR(.text);
+        __arm7_start__ = .;
+        KEEP (*(SORT_NONE(.init)))
+        *(.plt)
+        *(.text .stub .text.* .gnu.linkonce.t.*)
+        KEEP (*(.text.*personality*))
+        /* .gnu.warning sections are handled specially by elf32.em.  */
+        *(.gnu.warning)
+        *(.glue_7t) *(.glue_7) *(.v4_bx)
+        . = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
+    } >iwram AT>ewram :arm7
 
-	.rodata :
-	{
-		*(.rodata)
-		*all.rodata*(*)
-		*(.roda)
-		*(.rodata.*)
-		*(.gnu.linkonce.r*)
-		SORT(CONSTRUCTORS)
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >iwram AT>ewram
+    .fini           :
+    {
+        KEEP (*(.fini))
+    } >iwram AT>ewram
 
-	.ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >iwram AT>ewram
+    .rodata :
+    {
+        *(.rodata)
+        *all.rodata*(*)
+        *(.roda)
+        *(.rodata.*)
+        *(.gnu.linkonce.r*)
+        SORT(CONSTRUCTORS)
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >iwram AT>ewram
 
-	.ARM.exidx   : {
-		__exidx_start = .;
-		*(.ARM.exidx* .gnu.linkonce.armexidx.*)
-		__exidx_end = .;
-	 } >iwram AT>ewram
+    .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >iwram AT>ewram
 
-/* Ensure the __preinit_array_start label is properly aligned.  We
-   could instead move the label definition inside the section, but
-   the linker would then create the section even if it turns out to
-   be empty, which isn't pretty.  */
-	.preinit_array     : {
-		. = ALIGN(32 / 8);
-		PROVIDE (__preinit_array_start = .);
-		KEEP (*(.preinit_array))
-		PROVIDE (__preinit_array_end = .);
-	} >iwram AT>ewram
+    .ARM.exidx   : {
+        __exidx_start = .;
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+        __exidx_end = .;
+     } >iwram AT>ewram
 
-	.init_array     : {
-		PROVIDE (__init_array_start = .);
-		KEEP (*(.init_array))
-		PROVIDE (__init_array_end = .);
-	} >iwram AT>ewram
+    /* Ensure the __preinit_array_start label is properly aligned.  We
+       could instead move the label definition inside the section, but
+       the linker would then create the section even if it turns out to
+       be empty, which isn't pretty.  */
+    . = ALIGN(32 / 8);
+    .preinit_array :
+    {
+        PROVIDE (__preinit_array_start = .);
+        KEEP (*(.preinit_array))
+        PROVIDE (__preinit_array_end = .);
+    } >iwram AT>ewram
+    .init_array :
+    {
+        PROVIDE (__init_array_start = .);
+        KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
+        PROVIDE (__init_array_end = .);
+    } >iwram AT>ewram
+    .fini_array :
+    {
+        PROVIDE (__fini_array_start = .);
+        KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+        KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
+        PROVIDE (__fini_array_end = .);
+    } >iwram AT>ewram
 
-	.fini_array     : {
-		PROVIDE (__fini_array_start = .);
-		KEEP (*(.fini_array))
-		PROVIDE (__fini_array_end = .);
-	} >iwram AT>ewram
+    .ctors :
+    {
+        /* gcc uses crtbegin.o to find the start of
+           the constructors, so we make sure it is
+           first.  Because this is a wildcard, it
+           doesn't matter if the user does not
+           actually link against crtbegin.o; the
+           linker won't look for a file to match a
+           wildcard.  The wildcard also means that it
+           doesn't matter which directory crtbegin.o
+           is in.  */
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*crtbegin?.o(.ctors))
+        /* We don't want to include the .ctor section from
+           the crtend.o file until after the sorted ctors.
+           The .ctor section from the crtend file contains the
+           end of ctors marker and it must be last */
+        KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*(.ctors))
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >iwram AT>ewram
 
-	.ctors :
-	{
-	/* gcc uses crtbegin.o to find the start of the constructors, so
-		we make sure it is first.  Because this is a wildcard, it
-		doesn't matter if the user does not actually link against
-		crtbegin.o; the linker won't look for a file to match a
-		wildcard.  The wildcard also means that it doesn't matter which
-		directory crtbegin.o is in.  */
-		KEEP (*crtbegin.o(.ctors))
-		KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
-		KEEP (*(SORT(.ctors.*)))
-		KEEP (*(.ctors))
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >iwram AT>ewram
+    .dtors :
+    {
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*crtbegin?.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*(.dtors))
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >iwram AT>ewram
 
-	.dtors :
-	{
-		KEEP (*crtbegin.o(.dtors))
-		KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
-		KEEP (*(SORT(.dtors.*)))
-		KEEP (*(.dtors))
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >iwram AT>ewram
+    .eh_frame :
+    {
+        KEEP (*(.eh_frame))
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >iwram AT>ewram
 
-	.eh_frame :
-	{
-		KEEP (*(.eh_frame))
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >iwram AT>ewram
+    .gcc_except_table :
+    {
+        *(.gcc_except_table .gcc_except_table.*)
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >iwram AT>ewram
+    .got            : { *(.got.plt) *(.got) } >iwram AT>ewram
 
-	.gcc_except_table :
-	{
-		*(.gcc_except_table)
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >iwram AT>ewram
-	.jcr            : { KEEP (*(.jcr)) } >iwram AT>ewram
-	.got            : { *(.got.plt) *(.got) } >iwram AT>ewram
+    .data ALIGN(4) : 	{
+        __data_start = ABSOLUTE(.);
+        *(.data)
+        *(.data.*)
+        *(.gnu.linkonce.d*)
+        CONSTRUCTORS
+        . = ALIGN(4);
+    } >iwram AT>ewram
 
-	.data ALIGN(4) : 	{
-		__data_start = ABSOLUTE(.);
-		*(.data)
-		*(.data.*)
-		*(.gnu.linkonce.d*)
-		CONSTRUCTORS
-		. = ALIGN(4);
-	} >iwram AT>ewram
+    .tdata ALIGN(4) :
+    {
+        __tdata_start = ABSOLUTE(.);
+        *(.tdata .tdata.* .gnu.linkonce.td.*)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+        __tdata_end = ABSOLUTE(.);
+        __data_end = . ;
+    } >iwram AT>ewram
 
-	.tdata ALIGN(4) :
-	{
-		__tdata_start = ABSOLUTE(.) ;
-		*(.tdata .tdata.* .gnu.linkonce.td.*)
-		. = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
-		__tdata_end = ABSOLUTE(.) ;
-		__data_end = . ;
-	} >iwram AT>ewram
+    __tdata_size = __tdata_end - __tdata_start ;
 
-	__tdata_size = __tdata_end - __tdata_start ;
+    .tbss ALIGN(4) (NOLOAD) :
+    {
+         __tbss_start = ABSOLUTE(.);
+        *(.tbss .tbss.* .gnu.linkonce.tb.*)
+        *(.tcommon)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+         __tbss_end = ABSOLUTE(.);
+    } >iwram AT>ewram
 
-	.tbss ALIGN(4) (NOLOAD) :
-	{
-		 __tbss_start = ABSOLUTE(.) ;
-		*(.tbss .tbss.* .gnu.linkonce.tb.*)
-		*(.tcommon)
-		. = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
-		 __tbss_end = ABSOLUTE(.) ;
-	} >iwram AT>ewram
+    __tbss_size = __tbss_end - __tbss_start ;
 
-	__tbss_size = __tbss_end - __tbss_start ;
+    .bss ALIGN(4) (NOLOAD) :
+    {
+        __arm7_end__ = .;
+        __bss_start = ABSOLUTE(.);
+        __bss_start__ = ABSOLUTE(.);
+        *(.dynbss)
+        *(.gnu.linkonce.b*)
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+        __bss_end__ = ABSOLUTE(.);
+    } >iwram
 
-	.bss ALIGN(4) (NOLOAD) :
-	{
-		__arm7_end__ = .;
-		__bss_start = ABSOLUTE(.);
-		__bss_start__ = ABSOLUTE(.);
-		*(.dynbss)
-		*(.gnu.linkonce.b*)
-		*(.bss*)
-		*(COMMON)
-		. = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
-		__bss_end__ = ABSOLUTE(.);
-		__end__ = ABSOLUTE(.);
-	} >iwram
+    .noinit (NOLOAD):
+    {
+        __noinit_start = ABSOLUTE(.);
+        *(.noinit .noinit.* .gnu.linkonce.n.*)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+        __noinit_end = ABSOLUTE(.);
+        __end__ = ABSOLUTE(.);
+    } >iwram
 
-	/* Space reserved for the thread local storage of main() */
-	.tls ALIGN(4) (NOLOAD) :
-	{
-		__tls_start = ABSOLUTE(.) ;
-		. = . + __tdata_size + __tbss_size;
-		 __tls_end = ABSOLUTE(.) ;
-		__end__ = ABSOLUTE(.) ;
-	} >iwram
+    /* Space reserved for the thread local storage of main() */
+    .tls ALIGN(4) (NOLOAD) :
+    {
+        __tls_start = ABSOLUTE(.);
+        . = . + __tdata_size + __tbss_size;
+         __tls_end = ABSOLUTE(.);
+        __end__ = ABSOLUTE(.);
+    } >iwram
 
-	__tls_size = __tls_end - __tls_start;
+    __tls_size = __tls_end - __tls_start;
+    
+    HIDDEN(__arm7_size__ = __arm7_end__ - __arm7_start__);
+    HIDDEN(__arm7i_size__ = __arm7i_end__ - __arm7i_start__);
+    HIDDEN(__bss_size__ = __bss_end__ - __bss_start__);
+    HIDDEN(__twl_bss_size__ = __twl_bss_end__ - __twl_bss_start__);
 
-	/* Stabs debugging sections.  */
-	.stab 0 : { *(.stab) }
-	.stabstr 0 : { *(.stabstr) }
-	.stab.excl 0 : { *(.stab.excl) }
-	.stab.exclstr 0 : { *(.stab.exclstr) }
-	.stab.index 0 : { *(.stab.index) }
-	.stab.indexstr 0 : { *(.stab.indexstr) }
-	.comment 0 : { *(.comment) }
-	/*	DWARF debug sections.
-		Symbols in the DWARF debugging sections are relative to the beginning
-		of the section so we begin them at 0.  */
-	/* DWARF 1 */
-	.debug          0 : { *(.debug) }
-	.line           0 : { *(.line) }
-	/* GNU DWARF 1 extensions */
-	.debug_srcinfo  0 : { *(.debug_srcinfo) }
-	.debug_sfnames  0 : { *(.debug_sfnames) }
-	/* DWARF 1.1 and DWARF 2 */
-	.debug_aranges  0 : { *(.debug_aranges) }
-	.debug_pubnames 0 : { *(.debug_pubnames) }
-	/* DWARF 2 */
-	.debug_info     0 : { *(.debug_info) }
-	.debug_abbrev   0 : { *(.debug_abbrev) }
-	.debug_line     0 : { *(.debug_line) }
-	.debug_frame    0 : { *(.debug_frame) }
-	.debug_str      0 : { *(.debug_str) }
-	.debug_loc      0 : { *(.debug_loc) }
-	.debug_macinfo  0 : { *(.debug_macinfo) }
-	/* SGI/MIPS DWARF 2 extensions */
-	.debug_weaknames 0 : { *(.debug_weaknames) }
-	.debug_funcnames 0 : { *(.debug_funcnames) }
-	.debug_typenames 0 : { *(.debug_typenames) }
-	.debug_varnames  0 : { *(.debug_varnames) }
-	/* These must appear regardless of  .  */
+    /* Stabs debugging sections.  */
+    .stab          0 : { *(.stab) }
+    .stabstr       0 : { *(.stabstr) }
+    .stab.excl     0 : { *(.stab.excl) }
+    .stab.exclstr  0 : { *(.stab.exclstr) }
+    .stab.index    0 : { *(.stab.index) }
+    .stab.indexstr 0 : { *(.stab.indexstr) }
+    .comment 0 (INFO) : { *(.comment); LINKER_VERSION; }
+    .gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+    /* DWARF debug sections.
+       Symbols in the DWARF debugging sections are relative to the beginning
+       of the section so we begin them at 0.  */
+    /* DWARF 1.  */
+    .debug          0 : { *(.debug) }
+    .line           0 : { *(.line) }
+    /* GNU DWARF 1 extensions.  */
+    .debug_srcinfo  0 : { *(.debug_srcinfo) }
+    .debug_sfnames  0 : { *(.debug_sfnames) }
+    /* DWARF 1.1 and DWARF 2.  */
+    .debug_aranges  0 : { *(.debug_aranges) }
+    .debug_pubnames 0 : { *(.debug_pubnames) }
+    /* DWARF 2.  */
+    .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+    .debug_abbrev   0 : { *(.debug_abbrev) }
+    .debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+    .debug_frame    0 : { *(.debug_frame) }
+    .debug_str      0 : { *(.debug_str) }
+    .debug_loc      0 : { *(.debug_loc) }
+    .debug_macinfo  0 : { *(.debug_macinfo) }
+    /* SGI/MIPS DWARF 2 extensions.  */
+    .debug_weaknames 0 : { *(.debug_weaknames) }
+    .debug_funcnames 0 : { *(.debug_funcnames) }
+    .debug_typenames 0 : { *(.debug_typenames) }
+    .debug_varnames  0 : { *(.debug_varnames) }
+    /* DWARF 3.  */
+    .debug_pubtypes 0 : { *(.debug_pubtypes) }
+    .debug_ranges   0 : { *(.debug_ranges) }
+    /* DWARF 5.  */
+    .debug_addr     0 : { *(.debug_addr) }
+    .debug_line_str 0 : { *(.debug_line_str) }
+    .debug_loclists 0 : { *(.debug_loclists) }
+    .debug_macro    0 : { *(.debug_macro) }
+    .debug_names    0 : { *(.debug_names) }
+    .debug_rnglists 0 : { *(.debug_rnglists) }
+    .debug_str_offsets 0 : { *(.debug_str_offsets) }
+    .debug_sup      0 : { *(.debug_sup) }
+    .ARM.attributes 0 : { KEEP (*(.ARM.attributes)) KEEP (*(.gnu.attributes)) }
+    .note.gnu.arm.ident 0 : { KEEP (*(.note.gnu.arm.ident)) }
+    /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) }
 }

--- a/sys/crts/ds_arm7_crt0.s
+++ b/sys/crts/ds_arm7_crt0.s
@@ -13,9 +13,8 @@
 
 _start:
 
-    mov     r0, #0x04000000 // IME = 0
-    mov     r1, #0
-    str     r1, [r0, #0x208]
+    mov     r0, #0x04000000 // IME = 0;
+    str     r0, [r0, #0x208]
 
     mov     r0, #0x12       // Switch to IRQ Mode
     msr     cpsr, r0
@@ -45,8 +44,8 @@ _start:
     ldr     r1, [r0]
     add     r1, r1, r0
     ldr     r2, =__arm7_start__
-    ldr     r4, =__arm7_end__
-    bl      CopyMemCheck
+    ldr     r3, =__arm7_size__
+    bl      CopyMem
 
 #else
 
@@ -55,8 +54,7 @@ _start:
 #endif
 
     ldr     r0, =__bss_start__  // Clear BSS section to 0x00
-    ldr     r1, =__bss_end__
-    sub     r1, r1, r0
+    ldr     r1, =__bss_size__
     bl      ClearMem
 
     cmp     r10, #1             // r10 contains SCFG_A9ROM
@@ -69,12 +67,11 @@ _start:
     ldr     r1, =0x02ffe1d8     // Get ARM7i LMA from header
     ldr     r1, [r1]
     ldr     r2, =__arm7i_start__
-    ldr     r4, =__arm7i_end__
-    bl      CopyMemCheck
+    ldr     r3, =__arm7i_size__
+    bl      CopyMem
 
     ldr     r0, =__twl_bss_start__  // Clear TWL BSS section to 0x00
-    ldr     r1, =__twl_bss_end__
-    sub     r1, r1, r0
+    ldr     r1, =__twl_bss_size__
     bl      ClearMem
 
 #endif
@@ -173,22 +170,6 @@ ClrLoop:
     subs    r1, r1, #4
     bne     ClrLoop
     bx      lr
-
-// -----------------------------------------------------------------------------
-// Copy memory if length
-//  r1 = Source Address
-//  r2 = Dest Address
-//  r4 = Dest Address + Length (if length is zero, it returns right away)
-// -----------------------------------------------------------------------------
-
-CopyMemCheck:
-
-    cmp     r1, r2
-    bxeq    lr
-
-    sub     r3, r4, r2  // Is there any data to copy?
-
-    // Fallthrough
 
 // -----------------------------------------------------------------------------
 // Copy memory

--- a/sys/crts/ds_arm7_iwram.ld
+++ b/sys/crts/ds_arm7_iwram.ld
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright (C) 2014-2024 Free Software Foundation, Inc.
+   Copying and distribution of this script, with or without modification,
+   are permitted in any medium without royalty provided the copyright
+   notice and this notice are preserved.  */
+
+/* SPDX-License-Identifier: MPL-2.0 AND FSFAP */
 
 OUTPUT_FORMAT("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
 OUTPUT_ARCH(arm)
@@ -6,23 +11,30 @@ ENTRY(_start)
 
 /* User-configurable symbols. */
 
+/* The size, in bytes, of the amount of shared WRAM used by ARM7 code. */
+/* Only 0 and 32768 are valid values. */
+PROVIDE(__shared_wram_size = 32768);
+ASSERT(__shared_wram_size == 0 || __shared_wram_size == 32768, "ARM7 shared WRAM size must be 0 KB or 32 KB");
+
 /* The size, in bytes, of the reserved section at the end of IWRAM. */
 /* Traditionally, ARM7 reserves 0x40 bytes here. */
 PROVIDE(__iwram_reserved_size = 0x40);
+ASSERT((__iwram_reserved_size & 3) == 0, "__iwram_reserved_size must be a multiple of 4");
 
 /* ARM supervisor (SWI calls) stack size. */
 PROVIDE(__svc_stack_size = 0x100);
+ASSERT((__svc_stack_size & 3) == 0, "__svc_stack_size must be a multiple of 4");
 
 /* ARM interrupt handler stack size. */
 PROVIDE(__irq_stack_size = 0x100);
+ASSERT((__irq_stack_size & 3) == 0, "__irq_stack_size must be a multiple of 4");
 
 MEMORY {
-	rom	: ORIGIN = 0x08000000, LENGTH = 32M
-	iwram	: ORIGIN = 0x037f8000, LENGTH = 96K	
+    iwram : ORIGIN = 0x03800000 - __shared_wram_size, LENGTH = 65536 + __shared_wram_size	
 }
 
 __iwram_start	=	ORIGIN(iwram);
-__iwram_top	=	ORIGIN(iwram)+ LENGTH(iwram);
+__iwram_top	=	ORIGIN(iwram) + LENGTH(iwram);
 
 __sp_irq	=	__iwram_top - __iwram_reserved_size;
 __sp_svc	=	__sp_irq - __irq_stack_size;
@@ -34,197 +46,240 @@ __irq_vector	=	0x04000000 - 4;
 
 SECTIONS
 {
-	.crt0	:
-	{
-		__text_start = . ;
-		KEEP (*(.crt0))
-		. = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
-	} >iwram = 0xff
+    .crt0	:
+    {
+        __text_start = . ;
+        KEEP (*(.crt0))
+        . = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
+    } >iwram = 0xff
 
-	.init           :
-	{
-		KEEP (*(SORT_NONE(.init)))
-	} >iwram = 0xff
+    .init           :
+    {
+        KEEP (*(SORT_NONE(.init)))
+    } >iwram = 0xff
 
-	.plt : { *(.plt) } >iwram = 0xff
+    .plt : { *(.plt) } >iwram = 0xff
 
-	.text :   /* ALIGN (4): */
-	{
-		*(.text .stub .text.* .gnu.linkonce.t.*)
-		KEEP (*(.text.*personality*))
-		/* .gnu.warning sections are handled specially by elf32.em.  */
-		*(.gnu.warning)
-		*(.glue_7t) *(.glue_7) *(.vfp11_veneer)
-		. = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
-	} >iwram = 0xff
+    .text :   /* ALIGN (4): */
+    {
+        *(.text .stub .text.* .gnu.linkonce.t.*)
+        KEEP (*(.text.*personality*))
+        /* .gnu.warning sections are handled specially by elf32.em.  */
+        *(.gnu.warning)
+        *(.glue_7t) *(.glue_7) *(.v4_bx)
+        . = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
+    } >iwram = 0xff
 
-	.fini           :
-	{
-		KEEP (*(.fini))
-	} >iwram =0xff
+    .fini           :
+    {
+        KEEP (*(.fini))
+    } >iwram =0xff
 
-	__text_end = . ;
+    __text_end = . ;
 
-	.rodata :
-	{
-		*(.rodata)
-		*all.rodata*(*)
-		*(.roda)
-		*(.rodata.*)
-		*(.gnu.linkonce.r*)
-		SORT(CONSTRUCTORS)
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >iwram = 0xff
+    .rodata :
+    {
+        *(.rodata)
+        *all.rodata*(*)
+        *(.roda)
+        *(.rodata.*)
+        *(.gnu.linkonce.r*)
+        SORT(CONSTRUCTORS)
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >iwram = 0xff
 
-	.ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >iwram
-	__exidx_start = .;
-	.ARM.exidx   : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) } >iwram
-	__exidx_end = .;
+    .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >iwram
+    __exidx_start = .;
+    .ARM.exidx   : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) } >iwram
+    __exidx_end = .;
 
-/* Ensure the __preinit_array_start label is properly aligned.  We
-   could instead move the label definition inside the section, but
-   the linker would then create the section even if it turns out to
-   be empty, which isn't pretty.  */
-	. = ALIGN(32 / 8);
-	PROVIDE (__preinit_array_start = .);
-	.preinit_array     : { KEEP (*(.preinit_array)) } >iwram = 0xff
-	PROVIDE (__preinit_array_end = .);
-	PROVIDE (__init_array_start = .);
-	.init_array     : { KEEP (*(.init_array)) } >iwram = 0xff
-	PROVIDE (__init_array_end = .);
-	PROVIDE (__fini_array_start = .);
-	.fini_array     : { KEEP (*(.fini_array)) } >iwram = 0xff
-	PROVIDE (__fini_array_end = .);
+    /* Ensure the __preinit_array_start label is properly aligned.  We
+       could instead move the label definition inside the section, but
+       the linker would then create the section even if it turns out to
+       be empty, which isn't pretty.  */
+    . = ALIGN(32 / 8);
+    .preinit_array :
+    {
+        PROVIDE (__preinit_array_start = .);
+        KEEP (*(.preinit_array))
+        PROVIDE (__preinit_array_end = .);
+    } >iwram = 0xff
+    .init_array :
+    {
+        PROVIDE (__init_array_start = .);
+        KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
+        PROVIDE (__init_array_end = .);
+    } >iwram = 0xff
+    .fini_array :
+    {
+        PROVIDE (__fini_array_start = .);
+        KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+        KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
+        PROVIDE (__fini_array_end = .);
+    } >iwram = 0xff
 
-	.ctors :
-	{
-	/* gcc uses crtbegin.o to find the start of the constructors, so
-		we make sure it is first.  Because this is a wildcard, it
-		doesn't matter if the user does not actually link against
-		crtbegin.o; the linker won't look for a file to match a
-		wildcard.  The wildcard also means that it doesn't matter which
-		directory crtbegin.o is in.  */
-		KEEP (*crtbegin.o(.ctors))
-		KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
-		KEEP (*(SORT(.ctors.*)))
-		KEEP (*(.ctors))
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >iwram = 0xff
+    .ctors :
+    {
+        /* gcc uses crtbegin.o to find the start of
+           the constructors, so we make sure it is
+           first.  Because this is a wildcard, it
+           doesn't matter if the user does not
+           actually link against crtbegin.o; the
+           linker won't look for a file to match a
+           wildcard.  The wildcard also means that it
+           doesn't matter which directory crtbegin.o
+           is in.  */
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*crtbegin?.o(.ctors))
+        /* We don't want to include the .ctor section from
+           the crtend.o file until after the sorted ctors.
+           The .ctor section from the crtend file contains the
+           end of ctors marker and it must be last */
+        KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*(.ctors))
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >iwram = 0xff
 
-	.dtors :
-	{
-		KEEP (*crtbegin.o(.dtors))
-		KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
-		KEEP (*(SORT(.dtors.*)))
-		KEEP (*(.dtors))
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >iwram = 0xff
+    .dtors :
+    {
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*crtbegin?.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*(.dtors))
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >iwram = 0xff
 
-	.eh_frame :
-	{
-		KEEP (*(.eh_frame))
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >iwram = 0xff
+    .eh_frame :
+    {
+        KEEP (*(.eh_frame))
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >iwram = 0xff
 
-	.gcc_except_table :
-	{
-		*(.gcc_except_table)
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >iwram = 0xff
-	.jcr            : { KEEP (*(.jcr)) } >iwram = 0
-	.got            : { *(.got.plt) *(.got) } >iwram = 0
-
-
-	.data ALIGN(4) : 	{
-		__data_start = ABSOLUTE(.);
-		*(.data)
-		*(.data.*)
-		*(.gnu.linkonce.d*)
-		CONSTRUCTORS
-		. = ALIGN(4);
-		__data_end = ABSOLUTE(.) ;
-	} >iwram = 0xff
-
-	.tdata ALIGN(4) :
-	{
-		__tdata_start = ABSOLUTE(.) ;
-		*(.tdata .tdata.* .gnu.linkonce.td.*)
-		. = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
-		__tdata_end = ABSOLUTE(.) ;
-		__data_end = . ;
-	} >iwram = 0xff
-
-	__tdata_size = __tdata_end - __tdata_start ;
-
-	.tbss ALIGN(4) (NOLOAD) :
-	{
-		 __tbss_start = ABSOLUTE(.) ;
-		*(.tbss .tbss.* .gnu.linkonce.tb.*)
-		*(.tcommon)
-		. = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
-		 __tbss_end = ABSOLUTE(.) ;
-	} >iwram = 0xff
-
-	__tbss_size = __tbss_end - __tbss_start ;
-
-	__arm7_end__ = .;
+    .gcc_except_table :
+    {
+        *(.gcc_except_table .gcc_except_table.*)
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >iwram = 0xff
+    .got            : { *(.got.plt) *(.got) } >iwram = 0
 
 
-	.bss ALIGN(4) :
-	{
-		__bss_start = ABSOLUTE(.);
-		__bss_start__ = ABSOLUTE(.);
-		*(.dynbss)
-		*(.gnu.linkonce.b*)
-		*(.bss*)
-		*(COMMON)
-		. = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
-		__bss_end__ = ABSOLUTE(.);
-		__end__ = ABSOLUTE(.);
-	} >iwram
+    .data ALIGN(4) : 	{
+        __data_start = ABSOLUTE(.);
+        *(.data)
+        *(.data.*)
+        *(.gnu.linkonce.d*)
+        CONSTRUCTORS
+        . = ALIGN(4);
+        __data_end = ABSOLUTE(.);
+    } >iwram = 0xff
 
-	/* Space reserved for the thread local storage of main() */
-	.tls ALIGN(4) (NOLOAD) :
-	{
-		__tls_start = ABSOLUTE(.) ;
-		. = . + __tdata_size + __tbss_size;
-		 __tls_end = ABSOLUTE(.) ;
-		__end__ = ABSOLUTE(.) ;
-	} >iwram
+    .tdata ALIGN(4) :
+    {
+        __tdata_start = ABSOLUTE(.);
+        *(.tdata .tdata.* .gnu.linkonce.td.*)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+        __tdata_end = ABSOLUTE(.);
+        __data_end = . ;
+    } >iwram = 0xff
 
-	/* Stabs debugging sections.  */
-	.stab 0 : { *(.stab) }
-	.stabstr 0 : { *(.stabstr) }
-	.stab.excl 0 : { *(.stab.excl) }
-	.stab.exclstr 0 : { *(.stab.exclstr) }
-	.stab.index 0 : { *(.stab.index) }
-	.stab.indexstr 0 : { *(.stab.indexstr) }
-	.comment 0 : { *(.comment) }
-	/*	DWARF debug sections.
-		Symbols in the DWARF debugging sections are relative to the beginning
-		of the section so we begin them at 0.  */
-	/* DWARF 1 */
-	.debug          0 : { *(.debug) }
-	.line           0 : { *(.line) }
-	/* GNU DWARF 1 extensions */
-	.debug_srcinfo  0 : { *(.debug_srcinfo) }
-	.debug_sfnames  0 : { *(.debug_sfnames) }
-	/* DWARF 1.1 and DWARF 2 */
-	.debug_aranges  0 : { *(.debug_aranges) }
-	.debug_pubnames 0 : { *(.debug_pubnames) }
-	/* DWARF 2 */
-	.debug_info     0 : { *(.debug_info) }
-	.debug_abbrev   0 : { *(.debug_abbrev) }
-	.debug_line     0 : { *(.debug_line) }
-	.debug_frame    0 : { *(.debug_frame) }
-	.debug_str      0 : { *(.debug_str) }
-	.debug_loc      0 : { *(.debug_loc) }
-	.debug_macinfo  0 : { *(.debug_macinfo) }
-	/* SGI/MIPS DWARF 2 extensions */
-	.debug_weaknames 0 : { *(.debug_weaknames) }
-	.debug_funcnames 0 : { *(.debug_funcnames) }
-	.debug_typenames 0 : { *(.debug_typenames) }
-	.debug_varnames  0 : { *(.debug_varnames) }
-	.stack 0x80000 : { _stack = .; *(.stack) }
-	/* These must appear regardless of  .  */
+    __tdata_size = __tdata_end - __tdata_start ;
+
+    .tbss ALIGN(4) (NOLOAD) :
+    {
+         __tbss_start = ABSOLUTE(.);
+        *(.tbss .tbss.* .gnu.linkonce.tb.*)
+        *(.tcommon)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+         __tbss_end = ABSOLUTE(.);
+    } >iwram = 0xff
+
+    __tbss_size = __tbss_end - __tbss_start ;
+
+    __arm7_end__ = .;
+
+    .bss ALIGN(4) :
+    {
+        __bss_start = ABSOLUTE(.);
+        __bss_start__ = ABSOLUTE(.);
+        *(.dynbss)
+        *(.gnu.linkonce.b*)
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+        __bss_end__ = ABSOLUTE(.);
+    } >iwram
+
+    .noinit (NOLOAD):
+    {
+        __noinit_start = ABSOLUTE(.);
+        *(.noinit .noinit.* .gnu.linkonce.n.*)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+        __noinit_end = ABSOLUTE(.);
+        __end__ = ABSOLUTE(.);
+    } >iwram
+
+    /* Space reserved for the thread local storage of main() */
+    .tls ALIGN(4) (NOLOAD) :
+    {
+        __tls_start = ABSOLUTE(.);
+        . = . + __tdata_size + __tbss_size;
+         __tls_end = ABSOLUTE(.);
+        __end__ = ABSOLUTE(.);
+    } >iwram
+
+    HIDDEN(__arm7_size__ = __arm7_end__ - __arm7_start__);
+    HIDDEN(__bss_size__ = __bss_end__ - __bss_start__);
+
+    /* Stabs debugging sections.  */
+    .stab          0 : { *(.stab) }
+    .stabstr       0 : { *(.stabstr) }
+    .stab.excl     0 : { *(.stab.excl) }
+    .stab.exclstr  0 : { *(.stab.exclstr) }
+    .stab.index    0 : { *(.stab.index) }
+    .stab.indexstr 0 : { *(.stab.indexstr) }
+    .comment 0 (INFO) : { *(.comment); LINKER_VERSION; }
+    .gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+    /* DWARF debug sections.
+       Symbols in the DWARF debugging sections are relative to the beginning
+       of the section so we begin them at 0.  */
+    /* DWARF 1.  */
+    .debug          0 : { *(.debug) }
+    .line           0 : { *(.line) }
+    /* GNU DWARF 1 extensions.  */
+    .debug_srcinfo  0 : { *(.debug_srcinfo) }
+    .debug_sfnames  0 : { *(.debug_sfnames) }
+    /* DWARF 1.1 and DWARF 2.  */
+    .debug_aranges  0 : { *(.debug_aranges) }
+    .debug_pubnames 0 : { *(.debug_pubnames) }
+    /* DWARF 2.  */
+    .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+    .debug_abbrev   0 : { *(.debug_abbrev) }
+    .debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+    .debug_frame    0 : { *(.debug_frame) }
+    .debug_str      0 : { *(.debug_str) }
+    .debug_loc      0 : { *(.debug_loc) }
+    .debug_macinfo  0 : { *(.debug_macinfo) }
+    /* SGI/MIPS DWARF 2 extensions.  */
+    .debug_weaknames 0 : { *(.debug_weaknames) }
+    .debug_funcnames 0 : { *(.debug_funcnames) }
+    .debug_typenames 0 : { *(.debug_typenames) }
+    .debug_varnames  0 : { *(.debug_varnames) }
+    /* DWARF 3.  */
+    .debug_pubtypes 0 : { *(.debug_pubtypes) }
+    .debug_ranges   0 : { *(.debug_ranges) }
+    /* DWARF 5.  */
+    .debug_addr     0 : { *(.debug_addr) }
+    .debug_line_str 0 : { *(.debug_line_str) }
+    .debug_loclists 0 : { *(.debug_loclists) }
+    .debug_macro    0 : { *(.debug_macro) }
+    .debug_names    0 : { *(.debug_names) }
+    .debug_rnglists 0 : { *(.debug_rnglists) }
+    .debug_str_offsets 0 : { *(.debug_str_offsets) }
+    .debug_sup      0 : { *(.debug_sup) }
+    .ARM.attributes 0 : { KEEP (*(.ARM.attributes)) KEEP (*(.gnu.attributes)) }
+    .note.gnu.arm.ident 0 : { KEEP (*(.note.gnu.arm.ident)) }
+    /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) }
 }

--- a/sys/crts/ds_arm7_vram.ld
+++ b/sys/crts/ds_arm7_vram.ld
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright (C) 2014-2024 Free Software Foundation, Inc.
+   Copying and distribution of this script, with or without modification,
+   are permitted in any medium without royalty provided the copyright
+   notice and this notice are preserved.  */
+
+/* SPDX-License-Identifier: MPL-2.0 AND FSFAP */
 
 OUTPUT_FORMAT("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
 OUTPUT_ARCH(arm)
@@ -6,24 +11,31 @@ ENTRY(_start)
 
 /* User-configurable symbols. */
 
+/* The size, in bytes, of the amount of shared WRAM used by ARM7 code. */
+/* Only 0 and 32768 are valid values. */
+PROVIDE(__shared_wram_size = 32768);
+ASSERT(__shared_wram_size == 0 || __shared_wram_size == 32768, "ARM7 shared WRAM size must be 0 KB or 32 KB");
+
 /* The size, in bytes, of the reserved section at the end of IWRAM. */
 /* Traditionally, ARM7 reserves 0x40 bytes here. */
 PROVIDE(__iwram_reserved_size = 0x40);
+ASSERT((__iwram_reserved_size & 3) == 0, "__iwram_reserved_size must be a multiple of 4");
 
 /* ARM supervisor (SWI calls) stack size. */
 PROVIDE(__svc_stack_size = 0x100);
+ASSERT((__svc_stack_size & 3) == 0, "__svc_stack_size must be a multiple of 4");
 
 /* ARM interrupt handler stack size. */
 PROVIDE(__irq_stack_size = 0x100);
+ASSERT((__irq_stack_size & 3) == 0, "__irq_stack_size must be a multiple of 4");
 
 MEMORY {
-	rom	: ORIGIN = 0x08000000, LENGTH = 32M
-	iwram	: ORIGIN = 0x037f8000, LENGTH = 96K
-	vram	: ORIGIN = 0x06000000, LENGTH = 256K
+    iwram : ORIGIN = 0x03800000 - __shared_wram_size, LENGTH = 65536 + __shared_wram_size	
+    vram : ORIGIN = 0x06000000, LENGTH = 256K
 }
 
 __iwram_start	=	ORIGIN(iwram);
-__iwram_top	=	ORIGIN(iwram)+ LENGTH(iwram);
+__iwram_top	=	ORIGIN(iwram) + LENGTH(iwram);
 
 __sp_irq	=	__iwram_top - __iwram_reserved_size;
 __sp_svc	=	__sp_irq - __irq_stack_size;
@@ -35,200 +47,244 @@ __irq_vector	=	0x04000000 - 4;
 
 SECTIONS
 {
-	.crt0	:
-	{
-		__text_start = . ;
-		KEEP (*(.crt0))
-		. = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
-	} >vram = 0xff
+    .crt0	:
+    {
+        __text_start = . ;
+        KEEP (*(.crt0))
+        . = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
+    } >vram = 0xff
 
-	__arm7_lma__ = .;
-	__arm7_start__ = .;
-	.init           :
-	{
-		KEEP (*(SORT_NONE(.init)))
-	} >vram = 0xff
+    __arm7_lma__ = .;
+    __arm7_start__ = .;
+    .init           :
+    {
+        KEEP (*(SORT_NONE(.init)))
+    } >vram = 0xff
 
-	.plt : { *(.plt) } >vram = 0xff
+    .plt : { *(.plt) } >vram = 0xff
 
-	.text :   /* ALIGN (4): */
-	{
-		*(.text .stub .text.* .twl .gnu.linkonce.t.*)
-		KEEP (*(.text.*personality*))
-		/* .gnu.warning sections are handled specially by elf32.em.  */
-		*(.gnu.warning)
-		*(.glue_7t) *(.glue_7) *(.vfp11_veneer)
-		. = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
-	} >vram = 0xff
+    .text :   /* ALIGN (4): */
+    {
+        *(.text .stub .text.* .twl .gnu.linkonce.t.*)
+        KEEP (*(.text.*personality*))
+        /* .gnu.warning sections are handled specially by elf32.em.  */
+        *(.gnu.warning)
+        *(.glue_7t) *(.glue_7) *(.v4_bx)
+        . = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
+    } >vram = 0xff
 
-	.fini           :
-	{
-		KEEP (*(.fini))
-	} >vram =0xff
+    .fini           :
+    {
+        KEEP (*(.fini))
+    } >vram =0xff
 
-	__text_end = . ;
+    __text_end = . ;
 
-	.rodata :
-	{
-		*(.rodata)
-		*all.rodata*(*)
-		*(.roda)
-		*(.rodata.*)
-		*(.gnu.linkonce.r*)
-		SORT(CONSTRUCTORS)
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >vram = 0xff
+    .rodata :
+    {
+        *(.rodata)
+        *all.rodata*(*)
+        *(.roda)
+        *(.rodata.*)
+        *(.gnu.linkonce.r*)
+        SORT(CONSTRUCTORS)
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >vram = 0xff
 
-	.ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >vram
-	__exidx_start = .;
-	.ARM.exidx   : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) } >vram
-	__exidx_end = .;
+    .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >vram
+    __exidx_start = .;
+    .ARM.exidx   : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) } >vram
+    __exidx_end = .;
 
-/* Ensure the __preinit_array_start label is properly aligned.  We
-   could instead move the label definition inside the section, but
-   the linker would then create the section even if it turns out to
-   be empty, which isn't pretty.  */
-	. = ALIGN(32 / 8);
-	PROVIDE (__preinit_array_start = .);
-	.preinit_array     : { KEEP (*(.preinit_array)) } >vram = 0xff
-	PROVIDE (__preinit_array_end = .);
-	PROVIDE (__init_array_start = .);
-	.init_array     : { KEEP (*(.init_array)) } >vram = 0xff
-	PROVIDE (__init_array_end = .);
-	PROVIDE (__fini_array_start = .);
-	.fini_array     : { KEEP (*(.fini_array)) } >vram = 0xff
-	PROVIDE (__fini_array_end = .);
+    /* Ensure the __preinit_array_start label is properly aligned.  We
+       could instead move the label definition inside the section, but
+       the linker would then create the section even if it turns out to
+       be empty, which isn't pretty.  */
+    . = ALIGN(32 / 8);
+    .preinit_array :
+    {
+        PROVIDE (__preinit_array_start = .);
+        KEEP (*(.preinit_array))
+        PROVIDE (__preinit_array_end = .);
+    } >vram = 0xff
+    .init_array :
+    {
+        PROVIDE (__init_array_start = .);
+        KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
+        PROVIDE (__init_array_end = .);
+    } >vram = 0xff
+    .fini_array :
+    {
+        PROVIDE (__fini_array_start = .);
+        KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+        KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
+        PROVIDE (__fini_array_end = .);
+    } >vram = 0xff
 
-	.ctors :
-	{
-	/* gcc uses crtbegin.o to find the start of the constructors, so
-		we make sure it is first.  Because this is a wildcard, it
-		doesn't matter if the user does not actually link against
-		crtbegin.o; the linker won't look for a file to match a
-		wildcard.  The wildcard also means that it doesn't matter which
-		directory crtbegin.o is in.  */
-		KEEP (*crtbegin.o(.ctors))
-		KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
-		KEEP (*(SORT(.ctors.*)))
-		KEEP (*(.ctors))
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >vram = 0xff
+    .ctors :
+    {
+        /* gcc uses crtbegin.o to find the start of
+           the constructors, so we make sure it is
+           first.  Because this is a wildcard, it
+           doesn't matter if the user does not
+           actually link against crtbegin.o; the
+           linker won't look for a file to match a
+           wildcard.  The wildcard also means that it
+           doesn't matter which directory crtbegin.o
+           is in.  */
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*crtbegin?.o(.ctors))
+        /* We don't want to include the .ctor section from
+           the crtend.o file until after the sorted ctors.
+           The .ctor section from the crtend file contains the
+           end of ctors marker and it must be last */
+        KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*(.ctors))
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >vram = 0xff
 
-	.dtors :
-	{
-		KEEP (*crtbegin.o(.dtors))
-		KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
-		KEEP (*(SORT(.dtors.*)))
-		KEEP (*(.dtors))
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >vram = 0xff
+    .dtors :
+    {
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*crtbegin?.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*(.dtors))
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >vram = 0xff
 
-	.eh_frame :
-	{
-		KEEP (*(.eh_frame))
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >vram = 0xff
+    .eh_frame :
+    {
+        KEEP (*(.eh_frame))
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >vram = 0xff
 
-	.gcc_except_table :
-	{
-		*(.gcc_except_table)
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >vram = 0xff
-	.jcr            : { KEEP (*(.jcr)) } >vram = 0
-	.got            : { *(.got.plt) *(.got) } >vram = 0
-
-
-	.data ALIGN(4) : 	{
-		__data_start = ABSOLUTE(.);
-		*(.data)
-		*(.data.*)
-		*(.gnu.linkonce.d*)
-		CONSTRUCTORS
-		. = ALIGN(4);
-		__data_end = ABSOLUTE(.) ;
-	} >vram = 0xff
-
-	.tdata ALIGN(4) :
-	{
-		__tdata_start = ABSOLUTE(.) ;
-		*(.tdata .tdata.* .gnu.linkonce.td.*)
-		. = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
-		__tdata_end = ABSOLUTE(.) ;
-		__data_end = . ;
-	} >vram = 0xff
-
-	__tdata_size = __tdata_end - __tdata_start ;
-
-	.tbss ALIGN(4) (NOLOAD) :
-	{
-		 __tbss_start = ABSOLUTE(.) ;
-		*(.tbss .tbss.* .gnu.linkonce.tb.*)
-		*(.tcommon)
-		. = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
-		 __tbss_end = ABSOLUTE(.) ;
-	} >vram = 0xff
-
-	__tbss_size = __tbss_end - __tbss_start ;
-
-	__arm7_end__ = .;
+    .gcc_except_table :
+    {
+        *(.gcc_except_table .gcc_except_table.*)
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >vram = 0xff
+    .got            : { *(.got.plt) *(.got) } >vram = 0
 
 
-	.bss ALIGN(4) (NOLOAD) :
-	{
-		__bss_start = ABSOLUTE(.);
-		__bss_start__ = ABSOLUTE(.);
-		*(.dynbss)
-		*(.gnu.linkonce.b*)
-		*(.bss*)
-		*(.twl_bss)
-		*(COMMON)
-		. = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
-		__bss_end__ = ABSOLUTE(.);
-		__end__ = ABSOLUTE(.);
-	} >vram
+    .data ALIGN(4) : 	{
+        __data_start = ABSOLUTE(.);
+        *(.data)
+        *(.data.*)
+        *(.gnu.linkonce.d*)
+        CONSTRUCTORS
+        . = ALIGN(4);
+        __data_end = ABSOLUTE(.);
+    } >vram = 0xff
 
-	/* Space reserved for the thread local storage of main() */
-	.tls ALIGN(4) (NOLOAD) :
-	{
-		__tls_start = ABSOLUTE(.) ;
-		. = . + __tdata_size + __tbss_size;
-		 __tls_end = ABSOLUTE(.) ;
-		__end__ = ABSOLUTE(.) ;
-	} >vram
+    .tdata ALIGN(4) :
+    {
+        __tdata_start = ABSOLUTE(.);
+        *(.tdata .tdata.* .gnu.linkonce.td.*)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+        __tdata_end = ABSOLUTE(.);
+        __data_end = . ;
+    } >vram = 0xff
 
-	/* Stabs debugging sections.  */
-	.stab 0 : { *(.stab) }
-	.stabstr 0 : { *(.stabstr) }
-	.stab.excl 0 : { *(.stab.excl) }
-	.stab.exclstr 0 : { *(.stab.exclstr) }
-	.stab.index 0 : { *(.stab.index) }
-	.stab.indexstr 0 : { *(.stab.indexstr) }
-	.comment 0 : { *(.comment) }
-	/*	DWARF debug sections.
-		Symbols in the DWARF debugging sections are relative to the beginning
-		of the section so we begin them at 0.  */
-	/* DWARF 1 */
-	.debug          0 : { *(.debug) }
-	.line           0 : { *(.line) }
-	/* GNU DWARF 1 extensions */
-	.debug_srcinfo  0 : { *(.debug_srcinfo) }
-	.debug_sfnames  0 : { *(.debug_sfnames) }
-	/* DWARF 1.1 and DWARF 2 */
-	.debug_aranges  0 : { *(.debug_aranges) }
-	.debug_pubnames 0 : { *(.debug_pubnames) }
-	/* DWARF 2 */
-	.debug_info     0 : { *(.debug_info) }
-	.debug_abbrev   0 : { *(.debug_abbrev) }
-	.debug_line     0 : { *(.debug_line) }
-	.debug_frame    0 : { *(.debug_frame) }
-	.debug_str      0 : { *(.debug_str) }
-	.debug_loc      0 : { *(.debug_loc) }
-	.debug_macinfo  0 : { *(.debug_macinfo) }
-	/* SGI/MIPS DWARF 2 extensions */
-	.debug_weaknames 0 : { *(.debug_weaknames) }
-	.debug_funcnames 0 : { *(.debug_funcnames) }
-	.debug_typenames 0 : { *(.debug_typenames) }
-	.debug_varnames  0 : { *(.debug_varnames) }
-	.stack 0x80000 : { _stack = .; *(.stack) }
-	/* These must appear regardless of  .  */
+    __tdata_size = __tdata_end - __tdata_start ;
+
+    .tbss ALIGN(4) (NOLOAD) :
+    {
+         __tbss_start = ABSOLUTE(.);
+        *(.tbss .tbss.* .gnu.linkonce.tb.*)
+        *(.tcommon)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+         __tbss_end = ABSOLUTE(.);
+    } >vram = 0xff
+
+    __tbss_size = __tbss_end - __tbss_start ;
+
+    __arm7_end__ = .;
+
+
+    .bss ALIGN(4) (NOLOAD) :
+    {
+        __bss_start = ABSOLUTE(.);
+        __bss_start__ = ABSOLUTE(.);
+        *(.dynbss)
+        *(.gnu.linkonce.b*)
+        *(.bss*)
+        *(.twl_bss)
+        *(COMMON)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+        __bss_end__ = ABSOLUTE(.);
+    } >vram
+
+    .noinit (NOLOAD):
+    {
+        __noinit_start = ABSOLUTE(.);
+        *(.noinit .noinit.* .gnu.linkonce.n.*)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+        __noinit_end = ABSOLUTE(.);
+        __end__ = ABSOLUTE(.);
+    } >vram
+
+    /* Space reserved for the thread local storage of main() */
+    .tls ALIGN(4) (NOLOAD) :
+    {
+        __tls_start = ABSOLUTE(.);
+        . = . + __tdata_size + __tbss_size;
+         __tls_end = ABSOLUTE(.);
+        __end__ = ABSOLUTE(.);
+    } >vram
+
+    HIDDEN(__arm7_size__ = __arm7_end__ - __arm7_start__);
+    HIDDEN(__bss_size__ = __bss_end__ - __bss_start__);
+    
+    /* Stabs debugging sections.  */
+    .stab          0 : { *(.stab) }
+    .stabstr       0 : { *(.stabstr) }
+    .stab.excl     0 : { *(.stab.excl) }
+    .stab.exclstr  0 : { *(.stab.exclstr) }
+    .stab.index    0 : { *(.stab.index) }
+    .stab.indexstr 0 : { *(.stab.indexstr) }
+    .comment 0 (INFO) : { *(.comment); LINKER_VERSION; }
+    .gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+    /* DWARF debug sections.
+       Symbols in the DWARF debugging sections are relative to the beginning
+       of the section so we begin them at 0.  */
+    /* DWARF 1.  */
+    .debug          0 : { *(.debug) }
+    .line           0 : { *(.line) }
+    /* GNU DWARF 1 extensions.  */
+    .debug_srcinfo  0 : { *(.debug_srcinfo) }
+    .debug_sfnames  0 : { *(.debug_sfnames) }
+    /* DWARF 1.1 and DWARF 2.  */
+    .debug_aranges  0 : { *(.debug_aranges) }
+    .debug_pubnames 0 : { *(.debug_pubnames) }
+    /* DWARF 2.  */
+    .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+    .debug_abbrev   0 : { *(.debug_abbrev) }
+    .debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+    .debug_frame    0 : { *(.debug_frame) }
+    .debug_str      0 : { *(.debug_str) }
+    .debug_loc      0 : { *(.debug_loc) }
+    .debug_macinfo  0 : { *(.debug_macinfo) }
+    /* SGI/MIPS DWARF 2 extensions.  */
+    .debug_weaknames 0 : { *(.debug_weaknames) }
+    .debug_funcnames 0 : { *(.debug_funcnames) }
+    .debug_typenames 0 : { *(.debug_typenames) }
+    .debug_varnames  0 : { *(.debug_varnames) }
+    /* DWARF 3.  */
+    .debug_pubtypes 0 : { *(.debug_pubtypes) }
+    .debug_ranges   0 : { *(.debug_ranges) }
+    /* DWARF 5.  */
+    .debug_addr     0 : { *(.debug_addr) }
+    .debug_line_str 0 : { *(.debug_line_str) }
+    .debug_loclists 0 : { *(.debug_loclists) }
+    .debug_macro    0 : { *(.debug_macro) }
+    .debug_names    0 : { *(.debug_names) }
+    .debug_rnglists 0 : { *(.debug_rnglists) }
+    .debug_str_offsets 0 : { *(.debug_str_offsets) }
+    .debug_sup      0 : { *(.debug_sup) }
+    .ARM.attributes 0 : { KEEP (*(.ARM.attributes)) KEEP (*(.gnu.attributes)) }
+    .note.gnu.arm.ident 0 : { KEEP (*(.note.gnu.arm.ident)) }
+    /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) }
 }

--- a/sys/crts/ds_arm9.ld
+++ b/sys/crts/ds_arm9.ld
@@ -39,17 +39,17 @@ ASSERT((__usr_stack_size & 3) == 0, "__usr_stack_size must be a multiple of 4");
 __ewram_end	=	ORIGIN(ewram) + LENGTH(ewram);
 __eheap_end	=	ORIGIN(ewram) + LENGTH(ewram);
 
-__dtcm_top	=	ORIGIN(dtcm) + LENGTH(dtcm);
+__dtcm_start	=	ORIGIN(dtcm); /* Start of DTCM area. Must point to the beginning of DTCM memory. */
+__dtcm_top	=	ORIGIN(dtcm) + LENGTH(dtcm); /* Top of DTCM area. */
 __irq_flags	=	__dtcm_top - 0x08;
-__irq_vector =	__dtcm_top - 0x04;
+__irq_vector	=	__dtcm_top - 0x04;
 
-__dtcm_stack_top = __dtcm_top - __dtcm_data_size;
-__sp_svc	=	__dtcm_stack_top - __dtcm_reserved_size;
-__sp_irq	=	__sp_svc - __svc_stack_size;
-__sp_usr	=	__sp_irq - __irq_stack_size;
+__sp_svc	=	__dtcm_top - __dtcm_reserved_size; /* Top of SVC mode stack. */
+__sp_irq	=	__sp_svc - __svc_stack_size; /* Top of IRQ mode stack. */
+__sp_usr	=	__sp_irq - __irq_stack_size - __dtcm_data_size; /* Top of user stack. */
 
-__dtcm_data_start = __dtcm_data_size > 0 ? __sp_usr : ORIGIN(dtcm);
-__dtcm_data_top = __dtcm_data_size > 0 ? __dtcm_top : __sp_usr - __usr_stack_size;
+__dtcm_data_start = __dtcm_data_size > 0 ? __sp_usr : ORIGIN(dtcm); /* Start of DTCM data section. */
+__dtcm_data_top = __dtcm_data_size > 0 ? __sp_irq - __irq_stack_size : __sp_usr - __usr_stack_size; /* Top of DTCM data section. */
 
 __dldi_log2_size = LOG2CEIL(__dldi_size + 1) - 1;
 
@@ -247,7 +247,6 @@ SECTIONS
     .dtcm __dtcm_data_start :
     {
         __dtcm_lma = LOADADDR(.dtcm);
-        __dtcm_start = ABSOLUTE(.);
         *(.dtcm)
         *(.dtcm.*)
         . = ALIGN(4);
@@ -274,6 +273,7 @@ SECTIONS
         __sbss_start = ABSOLUTE(.);
         __sbss_start__ = ABSOLUTE(.);
         *(.sbss)
+        *(.sbss.*)
         . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
         __sbss_end = ABSOLUTE(.);
     } >dtcm :NONE
@@ -356,7 +356,7 @@ SECTIONS
     } :NONE
 
     HIDDEN(__itcm_size = __itcm_end - __itcm_start);
-    HIDDEN(__dtcm_size = __dtcm_end - __dtcm_start);
+    HIDDEN(__dtcm_data_size = __dtcm_end - __dtcm_data_start);
     HIDDEN(__arm9i_size__ = __arm9i_end__ - __arm9i_start__);
     HIDDEN(__bss_size__ = __bss_end__ - __bss_start__);
     HIDDEN(__sbss_size = __sbss_end - __sbss_start);

--- a/sys/crts/ds_arm9.ld
+++ b/sys/crts/ds_arm9.ld
@@ -1,4 +1,9 @@
-/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright (C) 2014-2024 Free Software Foundation, Inc.
+   Copying and distribution of this script, with or without modification,
+   are permitted in any medium without royalty provided the copyright
+   notice and this notice are preserved.  */
+
+/* SPDX-License-Identifier: MPL-2.0 AND FSFAP */
 
 OUTPUT_FORMAT("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
 OUTPUT_ARCH(arm)
@@ -6,338 +11,406 @@ ENTRY(_start)
 
 /* User-configurable symbols. */
 
+/* DTCM data area size. */
+/* If zero, DTCM data is placed at the beginning of the DTCM block, rather than the end. */
+PROVIDE(__dtcm_data_size = 0);
+ASSERT((__dtcm_data_size & 3) == 0, "__dtcm_data_size must be a multiple of 4");
+
 /* DLDI driver area size. */
 PROVIDE(__dldi_size = 16384);
 
 /* The size, in bytes, of the reserved section at the end of DTCM. */
 /* Traditionally, ARM9 reserves 0x40 bytes here. */
 PROVIDE(__dtcm_reserved_size = 0x40);
+ASSERT((__dtcm_reserved_size & 3) == 0, "__dtcm_reserved_size must be a multiple of 4");
 
 /* ARM supervisor (SWI calls) stack size. */
 PROVIDE(__svc_stack_size = 0x100);
+ASSERT((__svc_stack_size & 3) == 0, "__svc_stack_size must be a multiple of 4");
 
 /* ARM interrupt handler stack size. */
 PROVIDE(__irq_stack_size = 0x100);
+ASSERT((__irq_stack_size & 3) == 0, "__irq_stack_size must be a multiple of 4");
+
+/* ARM user stack size. Used only for stack smash validation at link time. */
+PROVIDE(__usr_stack_size = 0);
+ASSERT((__usr_stack_size & 3) == 0, "__usr_stack_size must be a multiple of 4");
 
 __ewram_end	=	ORIGIN(ewram) + LENGTH(ewram);
 __eheap_end	=	ORIGIN(ewram) + LENGTH(ewram);
 
 __dtcm_top	=	ORIGIN(dtcm) + LENGTH(dtcm);
 __irq_flags	=	__dtcm_top - 0x08;
-__irq_vector	=	__dtcm_top - 0x04;
+__irq_vector =	__dtcm_top - 0x04;
 
-__sp_svc	=	__dtcm_top - __dtcm_reserved_size;
+__dtcm_stack_top = __dtcm_top - __dtcm_data_size;
+__sp_svc	=	__dtcm_stack_top - __dtcm_reserved_size;
 __sp_irq	=	__sp_svc - __svc_stack_size;
 __sp_usr	=	__sp_irq - __irq_stack_size;
+
+__dtcm_data_start = __dtcm_data_size > 0 ? __sp_usr : ORIGIN(dtcm);
+__dtcm_data_top = __dtcm_data_size > 0 ? __dtcm_top : __sp_usr - __usr_stack_size;
 
 __dldi_log2_size = LOG2CEIL(__dldi_size + 1) - 1;
 
 PHDRS {
-	main    PT_LOAD FLAGS(7);
-	dtcm    PT_LOAD FLAGS(7);
-	itcm    PT_LOAD FLAGS(7);
-	twl     PT_LOAD FLAGS(0x100007);
+    main    PT_LOAD FLAGS(7);
+    dtcm    PT_LOAD FLAGS(7);
+    itcm    PT_LOAD FLAGS(7);
+    twl     PT_LOAD FLAGS(0x100007);
 }
 
 SECTIONS
 {
-	/* Secure area reserved space */
-	.secure : { *(.secure) } >ewram :main = 0
+    /* Secure area reserved space */
+    .secure : { *(.secure) } >ewram :main = 0
 
-	.crt0	:
-	{
-		__text_start = . ;
-		KEEP (*(.crt0))
-		. = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
-	} >ewram :main = 0x00
+    .crt0	:
+    {
+        __text_start = . ;
+        KEEP (*(.crt0))
+        . = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
+    } >ewram :main = 0x00
 
-	/* Create DLDI driver area. It should be zero-byte if DLDI code
-	   is not present, but set to an user-provided size if it is
+    /* Create DLDI driver area. It should be zero-byte if DLDI code
+       is not present, but set to an user-provided size if it is
            present. */
-	.dldi :
-	{
-		__dldi_start = .;
-		*(.dldi)
-		. = ALIGN(4);
+    .dldi :
+    {
+        __dldi_start = .;
+        *(.dldi)
+        . = ALIGN(4);
 
-		__dldi_data_end = .;
-		__dldi_end = __dldi_data_end > __dldi_start ? __dldi_start + __dldi_size : __dldi_start;
-		. = __dldi_end;
-		. = ALIGN(4);
-	} >ewram :main = 0x00
+        __dldi_data_end = .;
+        __dldi_end = __dldi_data_end > __dldi_start ? __dldi_start + __dldi_size : __dldi_start;
+        . = __dldi_end;
+        . = ALIGN(4);
+    } >ewram :main = 0x00
 
-	.plt : { *(.plt) } >ewram :main = 0xff
+    .plt : { *(.plt) } >ewram :main = 0xff
 
-	.init :
-	{
-		KEEP (*(SORT_NONE(.init)))
-	} >ewram :main
+    .init :
+    {
+        KEEP (*(SORT_NONE(.init)))
+    } >ewram :main
 
-	.text :   /* ALIGN (4): */
-	{
-		*(EXCLUDE_FILE(*.itcm* *.twl*) .text)
-		*(EXCLUDE_FILE(*.itcm* *.twl*) .stub)
-		*(EXCLUDE_FILE(*.itcm* *.twl*) .text.*)
-		/* .gnu.warning sections are handled specially by elf32.em.  */
-		*(EXCLUDE_FILE(*.twl*) .gnu.warning)
-		*(EXCLUDE_FILE(*.twl*) .gnu.linkonce.t*)
-		*(.glue_7)
-		*(.glue_7t)
-		. = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
-	} >ewram :main = 0xff
+    .text :   /* ALIGN (4): */
+    {
+        *(EXCLUDE_FILE(*.itcm* *.twl*) .text)
+        *(EXCLUDE_FILE(*.itcm* *.twl*) .stub)
+        *(EXCLUDE_FILE(*.itcm* *.twl*) .text.*)
+        /* .gnu.warning sections are handled specially by elf32.em.  */
+        *(EXCLUDE_FILE(*.twl*) .gnu.warning)
+        *(EXCLUDE_FILE(*.twl*) .gnu.linkonce.t*)
+        *(.glue_7)
+        *(.glue_7t)
+        . = ALIGN(4);  /* REQUIRED. LD is flaky without it. */
+    } >ewram :main = 0xff
 
-	.fini           :
-	{
-		KEEP (*(.fini))
-	} >ewram :main =0xff
+    .fini           :
+    {
+        KEEP (*(.fini))
+    } >ewram :main =0xff
 
-	__text_end = . ;
+    __text_end = . ;
 
-	.rodata :
-	{
-		*(EXCLUDE_FILE(*.twl*) .rodata)
-		*all.rodata*(*)
-		*(EXCLUDE_FILE(*.twl*) .roda)
-		*(EXCLUDE_FILE(*.twl*) .rodata.*)
-		*(EXCLUDE_FILE(*.twl*) .gnu.linkonce.r*)
-		SORT(CONSTRUCTORS)
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >ewram :main = 0xff
+    .rodata :
+    {
+        *(EXCLUDE_FILE(*.twl*) .rodata)
+        *all.rodata*(*)
+        *(EXCLUDE_FILE(*.twl*) .roda)
+        *(EXCLUDE_FILE(*.twl*) .rodata.*)
+        *(EXCLUDE_FILE(*.twl*) .gnu.linkonce.r*)
+        SORT(CONSTRUCTORS)
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >ewram :main = 0xff
 
-	.ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >ewram :main
- 	__exidx_start = .;
-	ARM.exidx   : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) } >ewram :main
- 	__exidx_end = .;
+    .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >ewram :main
+     __exidx_start = .;
+    ARM.exidx   : { *(.ARM.exidx* .gnu.linkonce.armexidx.*) } >ewram :main
+     __exidx_end = .;
 
-	/*	Ensure the __preinit_array_start label is properly aligned.  We
-		could instead move the label definition inside the section, but
-		the linker would then create the section even if it turns out to
-		be empty, which isn't pretty.  */
+    /* Ensure the __preinit_array_start label is properly aligned.  We
+       could instead move the label definition inside the section, but
+       the linker would then create the section even if it turns out to
+       be empty, which isn't pretty.  */
+    . = ALIGN(32 / 8);
+    .preinit_array :
+    {
+        PROVIDE (__preinit_array_start = .);
+        KEEP (*(.preinit_array))
+        PROVIDE (__preinit_array_end = .);
+    } >ewram :main = 0xff
+    .init_array :
+    {
+        PROVIDE (__init_array_start = .);
+        KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+        KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
+        PROVIDE (__init_array_end = .);
+    } >ewram :main = 0xff
+    .fini_array :
+    {
+        PROVIDE (__fini_array_start = .);
+        KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+        KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
+        PROVIDE (__fini_array_end = .);
+    } >ewram :main = 0xff
 
-	. = ALIGN(32 / 8);
+    .ctors :
+    {
+        /* gcc uses crtbegin.o to find the start of
+           the constructors, so we make sure it is
+           first.  Because this is a wildcard, it
+           doesn't matter if the user does not
+           actually link against crtbegin.o; the
+           linker won't look for a file to match a
+           wildcard.  The wildcard also means that it
+           doesn't matter which directory crtbegin.o
+           is in.  */
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*crtbegin?.o(.ctors))
+        /* We don't want to include the .ctor section from
+           the crtend.o file until after the sorted ctors.
+           The .ctor section from the crtend file contains the
+           end of ctors marker and it must be last */
+        KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*(.ctors))
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >ewram :main = 0xff
 
-	PROVIDE (__preinit_array_start = .);
-	.preinit_array     : { KEEP (*(.preinit_array)) } >ewram :main = 0xff
-	PROVIDE (__preinit_array_end = .);
-	PROVIDE (__init_array_start = .);
-	.init_array     :
-	{
-		KEEP (*(SORT(.init_array.*)))
-		KEEP (*(.init_array))
-	} >ewram :main = 0xff
-	PROVIDE (__init_array_end = .);
-	PROVIDE (__fini_array_start = .);
-	.fini_array     :
-	{
-		KEEP (*(.fini_array))
-		KEEP (*(SORT(.fini_array.*)))
-	} >ewram :main = 0xff
+    .dtors :
+    {
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*crtbegin?.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o *crtend?.o ) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*(.dtors))
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >ewram :main = 0xff
 
-	PROVIDE (__fini_array_end = .);
+    .eh_frame :
+    {
+        KEEP (*(.eh_frame))
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >ewram :main = 0xff
 
-	.ctors :
-	{
-	/*	gcc uses crtbegin.o to find the start of the constructors, so
-		we make sure it is first.  Because this is a wildcard, it
-		doesn't matter if the user does not actually link against
-		crtbegin.o; the linker won't look for a file to match a
-		wildcard.  The wildcard also means that it doesn't matter which
-		directory crtbegin.o is in.  */
-		KEEP (*crtbegin.o(.ctors))
-		KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
-		KEEP (*(SORT(.ctors.*)))
-		KEEP (*(.ctors))
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >ewram :main = 0xff
+    .gcc_except_table :
+    {
+        *(.gcc_except_table .gcc_except_table.*)
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >ewram :main = 0xff
+    .got            : { *(.got.plt) *(.got) *(.rel.got) } >ewram :main = 0
 
-	.dtors :
-	{
-		KEEP (*crtbegin.o(.dtors))
-		KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
-		KEEP (*(SORT(.dtors.*)))
-		KEEP (*(.dtors))
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >ewram :main = 0xff
+    .ewram ALIGN(4) : 
+    {
+        __ewram_start = ABSOLUTE(.);
+        *(.ewram)
+        *ewram.*(.text)
+        . = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
+    } >ewram :main = 0xff
 
-	.eh_frame :
-	{
-		KEEP (*(.eh_frame))
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >ewram :main = 0xff
+    .data ALIGN(4) :
+    {
+        __data_start = ABSOLUTE(.);
+        *(EXCLUDE_FILE(*.twl*) .data)
+        *(EXCLUDE_FILE(*.twl*) .data.*)
+        *(EXCLUDE_FILE(*.twl*) .gnu.linkonce.d*)
+        CONSTRUCTORS
+        . = ALIGN(4);
+    } >ewram :main = 0xff
 
-	.gcc_except_table :
-	{
-		*(.gcc_except_table)
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >ewram :main = 0xff
-	.jcr            : { KEEP (*(.jcr)) } >ewram :main = 0
-	.got            : { *(.got.plt) *(.got) *(.rel.got) } >ewram :main = 0
+    .tdata ALIGN(4) :
+    {
+        __tdata_start = ABSOLUTE(.);
+        *(.tdata .tdata.* .gnu.linkonce.td.*)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+        __tdata_end = ABSOLUTE(.);
+        __data_end = . ;
+    } >ewram :main = 0xff
 
-	.ewram ALIGN(4) : 
-	{
-		__ewram_start = ABSOLUTE(.) ;
-		*(.ewram)
-		*ewram.*(.text)
-		. = ALIGN(4);   /* REQUIRED. LD is flaky without it. */
-	} >ewram :main = 0xff
+    __tdata_size = __tdata_end - __tdata_start ;
 
+    .tbss ALIGN(4) :
+    {
+         __tbss_start = ABSOLUTE(.);
+        *(.tbss .tbss.* .gnu.linkonce.tb.*)
+        *(.tcommon)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+         __tbss_end = ABSOLUTE(.);
+    } >ewram :main = 0
 
-	.data ALIGN(4) :
-	{
-		__data_start = ABSOLUTE(.);
-		*(EXCLUDE_FILE(*.twl*) .data)
-		*(EXCLUDE_FILE(*.twl*) .data.*)
-		*(EXCLUDE_FILE(*.twl*) .gnu.linkonce.d*)
-		CONSTRUCTORS
-		. = ALIGN(4);
-	} >ewram :main = 0xff
+    __tbss_size = __tbss_end - __tbss_start ;
 
-	.tdata ALIGN(4) :
-	{
-		__tdata_start = ABSOLUTE(.) ;
-		*(.tdata .tdata.* .gnu.linkonce.td.*)
-		. = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
-		__tdata_end = ABSOLUTE(.) ;
-		__data_end = . ;
-	} >ewram :main = 0xff
+    __bss_vma = . ;
 
-	__tdata_size = __tdata_end - __tdata_start ;
+    .dtcm __dtcm_data_start :
+    {
+        __dtcm_lma = LOADADDR(.dtcm);
+        __dtcm_start = ABSOLUTE(.);
+        *(.dtcm)
+        *(.dtcm.*)
+        . = ALIGN(4);
+        __dtcm_end = ABSOLUTE(.);
+    } >dtcm AT>ewram :dtcm = 0xff
 
-	.tbss ALIGN(4) :
-	{
-		 __tbss_start = ABSOLUTE(.) ;
-		*(.tbss .tbss.* .gnu.linkonce.tb.*)
-		*(.tcommon)
-		. = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
-		 __tbss_end = ABSOLUTE(.) ;
-	} >ewram :main = 0
+    .itcm :
+    {
+        __itcm_lma = LOADADDR(.itcm);
+        __itcm_start = ABSOLUTE(.);
 
-	__tbss_size = __tbss_end - __tbss_start ;
+        /* Vectors must be placed at the beginning of ITCM. */
+        KEEP(*(.vectors .vectors.*))
 
-	__bss_vma = . ;
+        *(.itcm)
+        *(.itcm.*)
+        *.itcm*(.text .stub .text.*)
+        . = ALIGN(4);
+        __itcm_end = ABSOLUTE(.);
+    } >itcm AT>ewram :itcm = 0xff
 
-	.dtcm :
-	{
-		__dtcm_lma = LOADADDR(.dtcm);
-		__dtcm_start = ABSOLUTE(.);
-		*(.dtcm)
-		*(.dtcm.*)
-		. = ALIGN(4);
-		__dtcm_end = ABSOLUTE(.);
-	} >dtcm AT>ewram :dtcm = 0xff
+    .sbss __dtcm_end (NOLOAD): 
+    {
+        __sbss_start = ABSOLUTE(.);
+        __sbss_start__ = ABSOLUTE(.);
+        *(.sbss)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+        __sbss_end = ABSOLUTE(.);
+    } >dtcm :NONE
 
-	.itcm :
-	{
-		__itcm_lma = LOADADDR(.itcm);
-		__itcm_start = ABSOLUTE(.);
+    .bss __bss_vma (NOLOAD): 
+    {
+        __bss_start = ABSOLUTE(.);
+        __bss_start__ = ABSOLUTE(.);
+        *(EXCLUDE_FILE(*.twl*) .dynbss)
+        *(EXCLUDE_FILE(*.twl*) .gnu.linkonce.b*)
+        *(EXCLUDE_FILE(*.twl*) .bss*)
+        *(EXCLUDE_FILE(*.twl*) COMMON)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+        __bss_end__ = ABSOLUTE(.);
+    } >ewram :NONE
 
-		/* Vectors must be placed at the beginning of ITCM. */
-		KEEP(*(.vectors .vectors.*))
+    .noinit (NOLOAD):
+    {
+        __noinit_start = ABSOLUTE(.);
+        *(EXCLUDE_FILE(*.twl*) .noinit)
+        *(EXCLUDE_FILE(*.twl*) .noinit.*)
+        *(EXCLUDE_FILE(*.twl*) .gnu.linkonce.n.*)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+        __noinit_end = ABSOLUTE(.);
+    } >ewram :NONE
 
-		*(.itcm)
-		*(.itcm.*)
-		*.itcm*(.text .stub .text.*)
-		. = ALIGN(4);
-		__itcm_end = ABSOLUTE(.);
-	} >itcm AT>ewram :itcm = 0xff
+    /* Space reserved for the thread local storage of main() */
+    .tls ALIGN(4) (NOLOAD) :
+    {
+        __tls_start = ABSOLUTE(.);
+        . = . + __tdata_size + __tbss_size;
+         __tls_end = ABSOLUTE(.);
+        __end__ = ABSOLUTE(.);
+    } >ewram :NONE
 
-	.sbss __dtcm_end (NOLOAD): 
-	{
-		__sbss_start = ABSOLUTE(.);
-		__sbss_start__ = ABSOLUTE(.);
-		*(.sbss)
-		. = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
-		__sbss_end = ABSOLUTE(.);
-	} >dtcm :NONE
+    __tls_size = __tls_end - __tls_start ;
 
-	.bss __bss_vma (NOLOAD): 
-	{
-		__bss_start = ABSOLUTE(.);
-		__bss_start__ = ABSOLUTE(.);
-		*(EXCLUDE_FILE(*.twl*) .dynbss)
-		*(EXCLUDE_FILE(*.twl*) .gnu.linkonce.b*)
-		*(EXCLUDE_FILE(*.twl*) .bss*)
-		*(EXCLUDE_FILE(*.twl*) COMMON)
-		. = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
-		__bss_end__ = ABSOLUTE(.) ;
-	} >ewram :NONE
+    .twl __end__ : AT(MAX(0x2400000,__end__))
+    {
+        __arm9i_lma__ = LOADADDR(.twl);
+        __arm9i_start__ = ABSOLUTE(.);
+        *(.twl)
+        *(.twl.text .twl.text.*)
+        *(.twl.rodata .twl.rodata.*)
+        *(.twl.data .twl.data.*)
+        *.twl*(.text .stub .text.* .gnu.linkonce.t.*)
+        *.twl*(.rodata)
+        *.twl*(.roda)
+        *.twl*(.rodata.*)
+        *.twl*(.data)
+        *.twl*(.data.*)
+        *.twl*(.gnu.linkonce.d*)
+        __arm9i_end__ = ABSOLUTE(.);
+    } :twl
 
-	/* Space reserved for the thread local storage of main() */
-	.tls ALIGN(4) (NOLOAD) :
-	{
-		__tls_start = ABSOLUTE(.) ;
-		. = . + __tdata_size + __tbss_size;
-		 __tls_end = ABSOLUTE(.) ;
-		__end__ = ABSOLUTE(.) ;
-	} >ewram :NONE
+    .twl_bss __arm9i_end__ (NOLOAD):
+    {
+        __twl_bss_start__ = ABSOLUTE(.);
+        *(.twl_bss .twl_bss.*)
+        *(.twl.bss .twl.bss.*)
+        *.twl*(.dynbss)
+        *.twl*(.gnu.linkonce.b*)
+        *.twl*(.bss*)
+        *.twl*(COMMON)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+        __twl_bss_end__ = ABSOLUTE(.);
+    } :NONE
 
-	__tls_size = __tls_end - __tls_start ;
+    .twl_noinit __twl_bss_end__ (NOLOAD):
+    {
+        __twl_noinit_start__ = ABSOLUTE(.);
+        *(.twl_noinit .twl_noinit.*)
+        *(.twl.noinit .twl.noinit.*)
+        *.twl*(.noinit)
+        *.twl*(.noinit.*)
+        *.twl*(.gnu.linkonce.n.*)
+        . = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
+        __twl_noinit_end__ = ABSOLUTE(.);
+        __twl_end__ = ABSOLUTE(.);
+    } :NONE
 
-	.twl __end__ : AT(MAX(0x2400000,__end__))
-	{
-		__arm9i_lma__ = LOADADDR(.twl);
-		__arm9i_start__ = ABSOLUTE(.);
-		*(.twl)
-		*(.twl.text .twl.text.*)
-		*(.twl.rodata .twl.rodata.*)
-		*(.twl.data .twl.data.*)
-		*.twl*(.text .stub .text.* .gnu.linkonce.t.*)
-		*.twl*(.rodata)
-		*.twl*(.roda)
-		*.twl*(.rodata.*)
-		*.twl*(.data)
-		*.twl*(.data.*)
-		*.twl*(.gnu.linkonce.d*)
-		__arm9i_end__ = ABSOLUTE(.);
-	} :twl
+    HIDDEN(__itcm_size = __itcm_end - __itcm_start);
+    HIDDEN(__dtcm_size = __dtcm_end - __dtcm_start);
+    HIDDEN(__arm9i_size__ = __arm9i_end__ - __arm9i_start__);
+    HIDDEN(__bss_size__ = __bss_end__ - __bss_start__);
+    HIDDEN(__sbss_size = __sbss_end - __sbss_start);
+    HIDDEN(__twl_bss_size__ = __twl_bss_end__ - __twl_bss_start__);
 
-	.twl_bss __arm9i_end__ (NOLOAD):
-	{
-		__twl_bss_start__ = ABSOLUTE(.);
-		*(.twl_bss .twl_bss.*)
-		*(.twl.bss .twl.bss.*)
-		*.twl*(.dynbss)
-		*.twl*(.gnu.linkonce.b*)
-		*.twl*(.bss*)
-		*.twl*(COMMON)
-		. = ALIGN(4);    /* REQUIRED. LD is flaky without it. */
-		__twl_bss_end__ = ABSOLUTE(.);
-		__twl_end__ = ABSOLUTE(.);
-	} :NONE
-
-	/* Stabs debugging sections.  */
-	.stab 0 : { *(.stab) }
-	.stabstr 0 : { *(.stabstr) }
-	.stab.excl 0 : { *(.stab.excl) }
-	.stab.exclstr 0 : { *(.stab.exclstr) }
-	.stab.index 0 : { *(.stab.index) }
-	.stab.indexstr 0 : { *(.stab.indexstr) }
-	.comment 0 : { *(.comment) }
-	/*	DWARF debug sections.
-		Symbols in the DWARF debugging sections are relative to the beginning
-		of the section so we begin them at 0.  */
-	/* DWARF 1 */
-	.debug          0 : { *(.debug) }
-	.line           0 : { *(.line) }
-	/* GNU DWARF 1 extensions */
-	.debug_srcinfo  0 : { *(.debug_srcinfo) }
-	.debug_sfnames  0 : { *(.debug_sfnames) }
-	/* DWARF 1.1 and DWARF 2 */
-	.debug_aranges  0 : { *(.debug_aranges) }
-	.debug_pubnames 0 : { *(.debug_pubnames) }
-	/* DWARF 2 */
-	.debug_info     0 : { *(.debug_info) }
-	.debug_abbrev   0 : { *(.debug_abbrev) }
-	.debug_line     0 : { *(.debug_line) }
-	.debug_frame    0 : { *(.debug_frame) }
-	.debug_str      0 : { *(.debug_str) }
-	.debug_loc      0 : { *(.debug_loc) }
-	.debug_macinfo  0 : { *(.debug_macinfo) }
-	/* SGI/MIPS DWARF 2 extensions */
-	.debug_weaknames 0 : { *(.debug_weaknames) }
-	.debug_funcnames 0 : { *(.debug_funcnames) }
-	.debug_typenames 0 : { *(.debug_typenames) }
-	.debug_varnames  0 : { *(.debug_varnames) }
-	.stack 0x80000 : { _stack = .; *(.stack) }
-	/* These must appear regardless of  .  */
+    /* Stabs debugging sections.  */
+    .stab          0 : { *(.stab) }
+    .stabstr       0 : { *(.stabstr) }
+    .stab.excl     0 : { *(.stab.excl) }
+    .stab.exclstr  0 : { *(.stab.exclstr) }
+    .stab.index    0 : { *(.stab.index) }
+    .stab.indexstr 0 : { *(.stab.indexstr) }
+    .comment 0 (INFO) : { *(.comment); LINKER_VERSION; }
+    .gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
+    /* DWARF debug sections.
+       Symbols in the DWARF debugging sections are relative to the beginning
+       of the section so we begin them at 0.  */
+    /* DWARF 1.  */
+    .debug          0 : { *(.debug) }
+    .line           0 : { *(.line) }
+    /* GNU DWARF 1 extensions.  */
+    .debug_srcinfo  0 : { *(.debug_srcinfo) }
+    .debug_sfnames  0 : { *(.debug_sfnames) }
+    /* DWARF 1.1 and DWARF 2.  */
+    .debug_aranges  0 : { *(.debug_aranges) }
+    .debug_pubnames 0 : { *(.debug_pubnames) }
+    /* DWARF 2.  */
+    .debug_info     0 : { *(.debug_info .gnu.linkonce.wi.*) }
+    .debug_abbrev   0 : { *(.debug_abbrev) }
+    .debug_line     0 : { *(.debug_line .debug_line.* .debug_line_end) }
+    .debug_frame    0 : { *(.debug_frame) }
+    .debug_str      0 : { *(.debug_str) }
+    .debug_loc      0 : { *(.debug_loc) }
+    .debug_macinfo  0 : { *(.debug_macinfo) }
+    /* SGI/MIPS DWARF 2 extensions.  */
+    .debug_weaknames 0 : { *(.debug_weaknames) }
+    .debug_funcnames 0 : { *(.debug_funcnames) }
+    .debug_typenames 0 : { *(.debug_typenames) }
+    .debug_varnames  0 : { *(.debug_varnames) }
+    /* DWARF 3.  */
+    .debug_pubtypes 0 : { *(.debug_pubtypes) }
+    .debug_ranges   0 : { *(.debug_ranges) }
+    /* DWARF 5.  */
+    .debug_addr     0 : { *(.debug_addr) }
+    .debug_line_str 0 : { *(.debug_line_str) }
+    .debug_loclists 0 : { *(.debug_loclists) }
+    .debug_macro    0 : { *(.debug_macro) }
+    .debug_names    0 : { *(.debug_names) }
+    .debug_rnglists 0 : { *(.debug_rnglists) }
+    .debug_str_offsets 0 : { *(.debug_str_offsets) }
+    .debug_sup      0 : { *(.debug_sup) }
+    .ARM.attributes 0 : { KEEP (*(.ARM.attributes)) KEEP (*(.gnu.attributes)) }
+    .note.gnu.arm.ident 0 : { KEEP (*(.note.gnu.arm.ident)) }
+    /DISCARD/ : { *(.note.GNU-stack) *(.gnu_debuglink) *(.gnu.lto_*) }
 }
+
+ASSERT(__sbss_end <= __dtcm_data_top, "DTCM data overflow; increase __dtcm_data_size or move data out of DTCM");

--- a/sys/crts/ds_arm9_crt0.s
+++ b/sys/crts/ds_arm9_crt0.s
@@ -85,14 +85,14 @@ _start:
     // Copy ITCM from LMA to VMA
     ldr     r1, =__itcm_lma
     ldr     r2, =__itcm_start
-    ldr     r4, =__itcm_end
-    bl      CopyMemCheck
+    ldr     r3, =__itcm_size
+    bl      CopyMem
 
     // Copy DTCM from LMA to VMA
     ldr     r1, =__dtcm_lma
     ldr     r2, =__dtcm_start
-    ldr     r4, =__dtcm_end
-    bl      CopyMemCheck
+    ldr     r3, =__dtcm_size
+    bl      CopyMem
 
     cmp     r11, #1
     ldrne   r10, =__end__       // (DS mode) heap start
@@ -100,13 +100,11 @@ _start:
     bl      checkARGV           // Check and process argv trickery
 
     ldr     r0, =__bss_start__  // Clear BSS section
-    ldr     r1, =__bss_end__
-    sub     r1, r1, r0
+    ldr     r1, =__bss_size__
     bl      ClearMem
 
     ldr     r0, =__sbss_start   // Clear SBSS section
-    ldr     r1, =__sbss_end
-    sub     r1, r1, r0
+    ldr     r1, =__sbss_size
     bl      ClearMem
 
     ldr     r9, =__debugger_unit // Set DS/DSi debugger flag
@@ -123,12 +121,11 @@ _start:
 
     ldr     r2, =__arm9i_start__
     cmp     r1, r2              // Skip copy if LMA=VMA
-    ldrne   r4, =__arm9i_end__
-    blne    CopyMemCheck
+    ldrne   r3, =__arm9i_size__
+    blne    CopyMem
 
     ldr     r0, =__twl_bss_start__  // Clear TWL BSS section
-    ldr     r1, =__twl_bss_end__
-    sub     r1, r1, r0
+    ldr     r1, =__twl_bss_size__
     bl      ClearMem
 
 NotTWL:
@@ -240,19 +237,6 @@ ClrLoop:
     bne     ClrLoop
 
     bx      lr
-
-// -----------------------------------------------------------------------------
-// Copy memory if length    != 0
-//  r1 = Source Address
-//  r2 = Dest Address
-//  r4 = Dest Address + Length (if length is zero, it returns right away)
-// -----------------------------------------------------------------------------
-
-CopyMemCheck:
-
-    sub     r3, r4, r2  // Is there any data to copy?
-
-    // Fallthrough
 
 // -----------------------------------------------------------------------------
 // Copy memory

--- a/sys/crts/ds_arm9_crt0.s
+++ b/sys/crts/ds_arm9_crt0.s
@@ -90,8 +90,8 @@ _start:
 
     // Copy DTCM from LMA to VMA
     ldr     r1, =__dtcm_lma
-    ldr     r2, =__dtcm_start
-    ldr     r3, =__dtcm_size
+    ldr     r2, =__dtcm_data_start
+    ldr     r3, =__dtcm_data_size
     bl      CopyMem
 
     cmp     r11, #1


### PR DESCRIPTION
- Add a new user-configurable symbol, __dtcm_data_size. By default, it is set to 0, mimicking old behaviour (DTCM data placed at beginning of DTCM, stack placed at end of DTCM). However, if it is set to a non-zero value, DTCM data is placed at the end of DTCM, with stacks placed before it; this, in particular, allows the user stack to extend past DTCM and into main RAM.
- Add a new user-configurable symbol, __shared_wram_size.
- Add assertions for user-configurable size symbols being multiples of four.
- Add .noinit section support to link scripts.
- Add missing Free Software Foundation copyright notices to link scripts.
- Update link scripts with later changes done in GCC to the original link scripts that BlocksDS-provided scripts derive from.
- Minor crt0 cleanups; some redundant code has been removed, and memory copy/clear code has been adjusted to do the length subtractions at link time as opposed to runtime.

~~Posting as a draft as I have to go to bed and for some reason that I haven't had time to figure out, `__dtcm_data_size` doesn't work quite right. Try editing `Makefile.arm9` in `template_combined` to add to LDFLAGS: `-Wl,--defsym,__dtcm_data_size=1024` (won't work, but `=12288` will).~~ Fixed that one. Silly me.