### PR TITLE
Add ARM64 support to Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,9 @@ FROM ubuntu:23.04 AS base-cross-compiler
 
 ARG BRANCH=master
 
+# Set TARGETARCH e.g. amd64, arm64, riscv64.
+ARG TARGETARCH
+
 # Set locale for iconv, used by ndstool
 ENV LANG=C.UTF-8
 ENV LC_ALL=C.UTF-8
@@ -19,9 +22,13 @@ RUN apt-get update && apt-get upgrade -y && \
 
 RUN mkdir -p /opt/wonderful/
 ADD https://wonderful.asie.pl/bootstrap/wf-bootstrap-x86_64.tar.gz /opt/wonderful/
+ADD https://wonderful.asie.pl/bootstrap/wf-bootstrap-aarch64.tar.gz /opt/wonderful/
+# Note that the downloads are cached; no impact if it's a multi-platform build.
+# Needed because Docker's TARGETARCH doesn't match Linux's `uname -m` format.
+
 RUN cd /opt/wonderful/ && \
-    tar xzvf wf-bootstrap-x86_64.tar.gz && \
-    rm wf-bootstrap-x86_64.tar.gz
+    tar xzvf wf-bootstrap-$(uname -m).tar.gz && \
+    rm wf-bootstrap-*.tar.gz
 
 ENV PATH=/opt/wonderful/bin:$PATH
 
@@ -49,7 +56,8 @@ RUN apt-get install -y --no-install-recommends \
         build-essential
 
 # Install Teak toolchain only in the dev image
-RUN wf-pacman -S --noconfirm toolchain-llvm-teak-llvm
+RUN if [ $TARGETARCH = "amd64" ]; then \
+        wf-pacman -S --noconfirm toolchain-llvm-teak-llvm; fi
 
 WORKDIR /opt/
 RUN git clone --recurse-submodules https://github.com/blocksds/sdk.git \

--- a/docker/build-docker.sh
+++ b/docker/build-docker.sh
@@ -41,5 +41,5 @@ docker build --target blocksds-slim --tag blocksds:slim \
              --build-arg BRANCH=$BRANCH --platform $PLATFORM .
 docker tag blocksds:slim skylyrac/blocksds:slim-$VERSION
 
-#docker push skylyrac/blocksds:dev-$VERSION
-#docker push skylyrac/blocksds:slim-$VERSION
+docker push skylyrac/blocksds:dev-$VERSION
+docker push skylyrac/blocksds:slim-$VERSION

--- a/docker/build-docker.sh
+++ b/docker/build-docker.sh
@@ -25,17 +25,21 @@ if [ -z $BRANCH ]; then
     fi
 fi
 
+if [ -z $PLATFORM ]; then
+    PLATFORM="linux/amd64,linux/arm64"
+fi
 
 echo "VERSION = $VERSION"
 echo "BRANCH = $BRANCH"
+echo "PLATFORM = $PLATFORM"
 
 docker build --target blocksds-dev --tag blocksds:dev \
-             --build-arg BRANCH=$BRANCH .
+             --build-arg BRANCH=$BRANCH --platform $PLATFORM .
 docker tag blocksds:dev skylyrac/blocksds:dev-$VERSION
 
 docker build --target blocksds-slim --tag blocksds:slim \
-             --build-arg BRANCH=$BRANCH .
+             --build-arg BRANCH=$BRANCH --platform $PLATFORM .
 docker tag blocksds:slim skylyrac/blocksds:slim-$VERSION
 
-docker push skylyrac/blocksds:dev-$VERSION
-docker push skylyrac/blocksds:slim-$VERSION
+#docker push skylyrac/blocksds:dev-$VERSION
+#docker push skylyrac/blocksds:slim-$VERSION


### PR DESCRIPTION
Hi Antonio,

This PR is to add support for linux/arm64 platforms on the Docker image. This will allow users with 64 bit ARM computers (such as modern Macs and Raspberry Pis) to use BlocksDS on Docker natively. Builds were 8x faster on an M1 Mac mini, compared to emulation (16.526s vs 2m20.807s real time).

One thing to note is that llvm-teak is not available on aarch64/ARM64, so only the x86_64/AMD64 build includes the `toolchain-llvm-teak-llvm` package.

The `build-docker.sh` script was also updated to do a [multi-platform build](https://docs.docker.com/build/building/multi-platform/). A single image is produced, that can be run for both architectures. This process should be transparent to you on Docker Desktop, emulation is handled automatically.

You can try the ARM64 builds on an AMD64 machine and vice-versa. For example, `docker run --platform linux/arm64 -it --entrypoint bash skylyrac/blocksds:dev-latest`. You may need to [enable the contanierd image store](https://docs.docker.com/desktop/containerd/#build-multi-platform-images).

For testing I built the BlocksDS examples on both architectures. See the logs attached.
[make.amd64.log](https://github.com/user-attachments/files/17608051/make.amd64.log)
[make.arm64.log](https://github.com/user-attachments/files/17608052/make.arm64.log)

-- Ivan Veloz