### PR TITLE
docs: Update changelog

### DIFF
--- a/docs/content/introduction/changelog.md
+++ b/docs/content/introduction/changelog.md
@@ -10,8 +10,6 @@ weight: -20
   - Filesystem:
 
     - Fixed a bug involving incorrect reads of recently written sectors.
-    - Minor optimizations to read/write performance, particularly for
-      reads to unaligned buffers.
 
 ## Version 1.6.0 (2024-11-03)
 


### PR DESCRIPTION
The cache changes have uneven performance implications. I suppose there's always 1.7.0.