### PR TITLE
crts: fix thread-local storage initialization

### DIFF
--- a/sys/crts/ds_arm7_crt0.s
+++ b/sys/crts/ds_arm7_crt0.s
@@ -79,7 +79,7 @@ _start:
 NotTWL:
 
     // Initialize TLS of the main thread
-    ldr     r3, =__tls_start
+    ldr     r0, =__tls_start
     bl      init_tls
 
     ldr     r3, =__libc_init_array  // global constructors

--- a/sys/crts/ds_arm9_crt0.s
+++ b/sys/crts/ds_arm9_crt0.s
@@ -143,11 +143,17 @@ NotTWL:
     sub     r8, r8, #0xc000
     str     r8, [r1]
 
+    // Initialize libnds
     push    {r0}
-    ldr     r3, =initSystem         // System initialisation
+    ldr     r3, =initSystem
     blx     r3
 
-    ldr     r3, =__libc_init_array  // Global constructors
+    // Initialize TLS of the main thread
+    ldr     r0, =__tls_start
+    bl      init_tls
+
+    // Initialize global constructors
+    ldr     r3, =__libc_init_array 
     blx     r3
 
     pop     {r0}


### PR DESCRIPTION
- Fixed thread-local storage initialization on ARM7.
- Moved thread-local storage initialization to happen before global constructor initialization on ARM9 (in conjunction with related changes in libnds).

https://github.com/blocksds/libnds/pull/140