### PR TITLE
pacman: add build scripts and Linux GitHub CI

### DIFF
--- a/.github/workflows/pacman.yaml
+++ b/.github/workflows/pacman.yaml
@@ -1,0 +1,66 @@
+name: Build Pacman package
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-linux:
+    name: Build Pacman packages (Linux)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [x86_64, aarch64]
+    steps:
+      # + avoid recursive clone, as submodules are cloned again by makepkg
+      - name: Clone project
+        uses: actions/checkout@v4
+
+      - name: Setup Alpine Linux
+        uses: jirutka/setup-alpine@v1
+        with:
+          branch: v3.20
+          arch: ${{ matrix.arch }}
+          packages: >
+            build-base
+            fakeroot
+            git
+            pacman
+            pacman-makepkg
+            curl
+            wget
+            xz
+            zstd
+            sudo
+            coreutils
+            sed
+            patchelf
+
+      - name: Install Wonderful
+        run: |
+          sudo sh -c "mkdir /opt/wonderful && cd /opt/wonderful && curl https://wonderful.asie.pl/bootstrap/wf-bootstrap-${{ matrix.arch }}.tar.gz | tar xzvf -"
+        shell: alpine.sh --root {0}
+
+      # + remove CheckSpace, as it doesn't work in chroot without providing mount point data
+      # + do so twice, as wf-pacman might upgrade wf-pacman
+      # + ensure system makepkg outputs .tar.xz files
+      - name: Install prerequisites (Wonderful)
+        run: |
+          sed -i -e 's/CheckSpace//' /opt/wonderful/etc/pacman.conf
+          /opt/wonderful/bin/wf-pacman -Syu --noconfirm wonderful-base wf-pacman-dev
+          sed -i -e 's/CheckSpace//' /opt/wonderful/etc/pacman.conf
+          sed -E -i -e "s/PKGEXT=.+/PKGEXT='.pkg.tar.xz'/g" /etc/makepkg.conf
+        shell: alpine.sh --root {0}
+
+      - name: Build package
+        run: |
+           cd ${{ github.workspace }}/pacman && /opt/wonderful/bin/wf-makepkg -s --noconfirm
+        shell: alpine.sh {0}
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Pacman packages (Linux, ${{ matrix.arch }})
+          path: ${{ github.workspace }}/pacman/*.pkg.tar.xz
+

--- a/pacman/PKGBUILD
+++ b/pacman/PKGBUILD
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: Adrian "asie" Siekierka, 2023, 2024
+
+pkgname=(blocksds-toolchain blocksds-docs)
+source=("blocksds::git+file://`pwd`/..")
+sha256sums=('SKIP')
+groups=(blocksds)
+pkgver=1.6.3
+pkgrel=1
+epoch=
+pkgdesc="DS/DSi console homebrew toolchain maintained by AntonioND"
+arch=("x86_64" "aarch64")
+url="https://github.com/blocksds/sdk"
+license=("complex")
+depends=(
+	runtime-gcc-libs
+	runtime-musl
+	toolchain-gcc-arm-none-eabi-binutils
+	toolchain-gcc-arm-none-eabi-gcc-libs
+	toolchain-gcc-arm-none-eabi-gcc
+	toolchain-gcc-arm-none-eabi-picolibc-generic
+	toolchain-gcc-arm-none-eabi-libstdcxx-picolibc
+)
+makedepends=(
+	runtime-musl-dev
+)
+optdepends=(
+	'toolchain-gcc-arm-none-eabi-extra: additional libraries'
+)
+replaces=(thirdparty-blocksds-toolchain thirdparty-blocksds-git-toolchain)
+options=('!strip')
+
+. "/opt/wonderful/lib/wf-pacman/runtime-env-vars.sh"
+
+if [ "$WF_HOST_OS" == "linux" ]; then
+	if [ "$CARCH" == "x86_64" ]; then
+		makedepends+=(toolchain-llvm-teak-llvm )
+		optdepends+=('toolchain-llvm-teak-llvm: Teak DSP build support')
+	fi
+fi
+
+prepare() {
+	cd "blocksds"
+	git submodule update --init --recursive
+
+	wf_disable_host_build
+
+	if [ "$WF_HOST_OS" == "windows" ]; then
+		# patch ndstool to link iconv explicitly
+		sed -i -e 's/$(LIBS)/$(LIBS) -liconv/' tools/ndstool/Makefile
+	fi
+}
+
+build() {
+	wf_use_toolchain gcc-arm-none-eabi arm-none-eabi
+
+	cd "blocksds"
+	BLOCKSDS=`pwd` make
+}
+
+package_blocksds-toolchain() {
+	cd "blocksds"
+	mkdir -p "$pkgdir$WF_DESTDIR"/thirdparty/blocksds/core
+
+	BLOCKSDS=`pwd` INSTALLDIR="$pkgdir$WF_DESTDIR"/thirdparty/blocksds/core make -j1 install
+
+	# patch compiled executables to use /opt/wonderful dynamic linker
+	find "$pkgdir$WF_DESTDIR"/thirdparty/blocksds/core/tools -executable -type f -print0 |
+		while IFS= read -r -d '' i; do
+			# this will fail on statically-linked grit; consume the error
+			wf_runtime_patchelf "$i" || true
+		done
+}
+
+package_blocksds-docs() {
+	depends=(blocksds-toolchain)
+	optdepends=()
+	replaces=(thirdparty-blocksds-docs thirdparty-blocksds-git-docs)
+
+	cd "blocksds"
+
+	mkdir -p "$pkgdir$WF_DESTDIR"/thirdparty/blocksds/core
+	cp -aR docs "$pkgdir$WF_DESTDIR"/thirdparty/blocksds/core || true
+	cp -aR examples "$pkgdir$WF_DESTDIR"/thirdparty/blocksds/core || true
+	cp -aR templates "$pkgdir$WF_DESTDIR"/thirdparty/blocksds/core || true
+	cp -aR tests "$pkgdir$WF_DESTDIR"/thirdparty/blocksds/core || true
+}


### PR DESCRIPTION
Extracted from `wonderful-packages` and slightly tweaked to work outside of that build system. To be done on your end:

- Figure out a versioning scheme. If you're going to ingest Git builds into your own repository, you might want to either include the number of Git commits in the package's version number (so updates work), or even have separate Git and  stable packages like I used to. I removed this from the PR for simplicity, but [this](https://github.com/WonderfulToolchain/wonderful-packages/blob/main/packages/thirdparty-blocksds/PKGBUILD#L5-L15) is what you need to have multiple package names in a multi-package project, and [this](https://github.com/WonderfulToolchain/wonderful-packages/blob/main/packages/templates/git-pkgver.PKGBUILD) allows pulling in information from the Git repository.
- Windows builds. I'm not even *trying* to automate that, sorry.
- Configuring the `on` rules to match your project's needs.