### PR TITLE
Add CMake build scripts and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ install: all
 	+$(MAKE) -C libs install INSTALLDIR=$(INSTALLDIR_ABS)/libs
 	+$(MAKE) -C sys install INSTALLDIR=$(INSTALLDIR_ABS)/sys
 	+$(MAKE) -C tools install INSTALLDIR=$(INSTALLDIR_ABS)/tools
+	+$(CP) -r sys/cmake $(INSTALLDIR_ABS)/cmake
 	+$(CP) -r licenses $(INSTALLDIR_ABS)
 	@if [ `git rev-parse HEAD 2> /dev/null` ]; then \
 		git rev-parse HEAD > $(INSTALLDIR)/version.txt ; \

--- a/examples/cmake/portable_demo/CMakeLists.txt
+++ b/examples/cmake/portable_demo/CMakeLists.txt
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: ds-sloth, 2024
+
+cmake_minimum_required(VERSION 3.16)
+
+project(portable_demo LANGUAGES C)
+
+set(PORTABLE_DEMO_SRC
+    src/cross_platform_logic.c
+)
+
+if(NINTENDO_DS)
+    LIST(APPEND PORTABLE_DEMO_SRC
+        src/nds/main_nds.c
+    )
+else()
+    LIST(APPEND PORTABLE_DEMO_SRC
+        src/posix/main_posix.c
+    )
+endif()
+
+add_executable(portable_demo ${PORTABLE_DEMO_SRC})
+
+target_include_directories(portable_demo PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+if(NINTENDO_DS)
+    if(NDS_DSI_EXCLUSIVE)
+        set(SUBTITLE "DSi Edition")
+    else()
+        set(SUBTITLE "Same logic everywhere")
+    endif()
+
+    nds_create_rom(portable_demo
+        NAME "Portable Demo"
+        SUBTITLE "${SUBTITLE}"
+        AUTHOR "ds-sloth"
+    )
+endif()

--- a/examples/cmake/portable_demo/README.md
+++ b/examples/cmake/portable_demo/README.md
@@ -1,0 +1,31 @@
+## Portable Demo
+
+This project provides an example application that builds for both NDS and POSIX (computer) platforms.
+
+### Usage
+
+To build an executable native to your host system:
+```
+mkdir -p build/POSIX
+cd build/POSIX
+cmake ../..
+make
+```
+
+To build an executable for NDS:
+```
+mkdir -p build/NDS
+cd build/NDS
+cmake ../.. -DCMAKE_TOOLCHAIN_FILE=$BLOCKSDS/cmake/BlocksDS.cmake
+make
+```
+
+To build a DSi-exclusive executable:
+```
+mkdir -p build/DSi
+cd build/DSi
+cmake ../.. -DCMAKE_TOOLCHAIN_FILE=$BLOCKSDS/cmake/BlocksDSi.cmake
+make
+```
+
+Note that such an executable may violate the NDS ROM specifications and fail to load in some environments.

--- a/examples/cmake/portable_demo/src/cross_platform_logic.c
+++ b/examples/cmake/portable_demo/src/cross_platform_logic.c
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: ds-sloth, 2024
+
+#include "cross_platform_logic.h"
+
+int cross_platform_program()
+{
+    return 42;
+}

--- a/examples/cmake/portable_demo/src/cross_platform_logic.h
+++ b/examples/cmake/portable_demo/src/cross_platform_logic.h
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: ds-sloth, 2024
+
+#pragma once
+
+// this function does something that does not depend on the platform details
+int cross_platform_program();

--- a/examples/cmake/portable_demo/src/nds/main_nds.c
+++ b/examples/cmake/portable_demo/src/nds/main_nds.c
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: ds-sloth, 2024
+
+#include "cross_platform_logic.h"
+
+#include <stdio.h>
+
+#include <nds.h>
+
+int main(int argc, char **argv)
+{
+    consoleDemoInit();
+
+    int result = cross_platform_program();
+
+    printf("The answer is... %d\n", result);
+
+    printf("Press START to exit to loader\n");
+
+    while (1)
+    {
+        swiWaitForVBlank();
+
+        scanKeys();
+
+        if (keysDown() & KEY_START)
+            break;
+    }
+
+    return 0;
+}

--- a/examples/cmake/portable_demo/src/posix/main_posix.c
+++ b/examples/cmake/portable_demo/src/posix/main_posix.c
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: ds-sloth, 2024
+
+#include "cross_platform_logic.h"
+
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+    int result = cross_platform_program();
+
+    printf("The answer is... %d\n", result);
+
+    return 0;
+}

--- a/sys/cmake/BlocksDS-rule-overrides.cmake
+++ b/sys/cmake/BlocksDS-rule-overrides.cmake
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: ds-sloth, 2024
+
+# Written to mimic devkitPro defaults to reduce migration surprises.
+
+foreach(LANG IN ITEMS C CXX ASM)
+    set(CMAKE_${LANG}_OUTPUT_EXTENSION .o)
+    set(CMAKE_${LANG}_OUTPUT_EXTENSION_REPLACE 1)
+
+    set(CMAKE_${LANG}_FLAGS_DEBUG_INIT          " -g -Og -DDEBUG")
+    set(CMAKE_${LANG}_FLAGS_MINSIZEREL_INIT     " -g -Oz -DNDEBUG")
+    set(CMAKE_${LANG}_FLAGS_RELEASE_INIT        " -g -O2 -DNDEBUG")
+    set(CMAKE_${LANG}_FLAGS_RELWITHDEBINFO_INIT " -g -O2 -DNDEBUG")
+endforeach()

--- a/sys/cmake/BlocksDS.cmake
+++ b/sys/cmake/BlocksDS.cmake
@@ -1,0 +1,226 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: ds-sloth, 2024
+
+
+cmake_minimum_required(VERSION 3.16)
+
+
+
+if(NOT CMAKE_SYSTEM_NAME)
+    # Note: this will cause Platform/NintendoDS.cmake to be loaded at the correct stage.
+    set(CMAKE_SYSTEM_NAME NintendoDS)
+endif()
+
+if(NOT CMAKE_SYSTEM_VERSION)
+    set(CMAKE_SYSTEM_VERSION 1)
+endif()
+
+if(NOT CMAKE_SYSTEM_PROCESSOR)
+    set(CMAKE_SYSTEM_PROCESSOR armv5te)
+endif()
+
+if(CMAKE_HOST_WIN32)
+    message(FATAL_ERROR "The BlocksDS CMake toolchain requires a posix-like environment (mwingw, msys, etc)")
+endif()
+
+if(NOT "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv5te")
+    message(FATAL_ERROR "This CMake toolchain can only produce binaries for armv5te. (CMAKE_SYSTEM_PROCESSOR [${CMAKE_SYSTEM_PROCESSOR}] requested).")
+endif()
+
+set(NINTENDO_DS TRUE)
+set(ARM9 TRUE)
+
+
+
+# initialize basic platform properties
+list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES NDS_ARCH_THUMB)
+list(APPEND CMAKE_TRY_COMPILE_PLATFORM_VARIABLES NDS_DSI_EXCLUSIVE)
+
+if(NOT CMAKE_USER_MAKE_RULES_OVERRIDE)
+    set(CMAKE_USER_MAKE_RULES_OVERRIDE ${CMAKE_CURRENT_LIST_DIR}/BlocksDS-rule-overrides.cmake)
+endif()
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+
+
+
+# find WONDERFUL_TOOLCHAIN and BLOCKSDS
+if(NOT DEFINED ENV{WONDERFUL_TOOLCHAIN})
+    message(FATAL_ERROR "Ensure that environment variable WONDERFUL_TOOLCHAIN is set.")
+else()
+    set(WONDERFUL_TOOLCHAIN "$ENV{WONDERFUL_TOOLCHAIN}")
+endif()
+
+if(NOT DEFINED ENV{BLOCKSDS})
+    if(EXISTS "/opt/blocksds/core/")
+        set(BLOCKSDS "/opt/blocksds/core")
+    elseif(EXISTS "${WONDERFUL_TOOLCHAIN}/thirdparty/blocksds/core/")
+        set(BLOCKSDS "${WONDERFUL_TOOLCHAIN}/thirdparty/blocksds/core")
+    else()
+        message(FATAL_ERROR "BlocksDS not found. Ensure that environment variable BLOCKSDS is set.")
+    endif()
+else()
+    set(BLOCKSDS "$ENV{BLOCKSDS}")
+endif()
+
+if(NOT DEFINED ENV{BLOCKSDSEXT})
+    if(EXISTS "/opt/blocksds/external/")
+        set(BLOCKSDSEXT "/opt/blocksds/external")
+    elseif(EXISTS "${WONDERFUL_TOOLCHAIN}/thirdparty/blocksds/external/")
+        set(BLOCKSDSEXT "${WONDERFUL_TOOLCHAIN}/thirdparty/blocksds/external")
+    else()
+        set(BLOCKSDSEXT "")
+    endif()
+else()
+    set(BLOCKSDSEXT "$ENV{BLOCKSDSEXT}")
+endif()
+
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "${BLOCKSDSEXT}" CACHE PATH
+        "Install path prefix, prepended onto install directories." FORCE)
+endif()
+
+
+
+# initialize search paths and executables for the desired triplet
+set(BLOCKSDS_TRIPLET "arm-none-eabi")
+
+# Prefer config mode for find_package (matches dkP logic)
+set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)
+
+set(CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH OFF)
+string(REPLACE ":" ";" CMAKE_SYSTEM_PROGRAM_PATH "$ENV{PATH}")
+
+set(CMAKE_SYSTEM_PREFIX_PATH
+    ${BLOCKSDSEXT}
+    ${BLOCKSDS}/libs/dswifi
+    ${BLOCKSDS}/libs/libteak
+    ${BLOCKSDS}/libs/libxm7
+    ${BLOCKSDS}/libs/maxmod
+    ${BLOCKSDS}/libs/libnds
+    ${WONDERFUL_TOOLCHAIN}/toolchain/gcc-${BLOCKSDS_TRIPLET}
+    ${WONDERFUL_TOOLCHAIN}/toolchain/gcc-${BLOCKSDS_TRIPLET}/${BLOCKSDS_TRIPLET}
+    ${BLOCKSDS}/tools/ndstool
+)
+
+set(TOOLCHAIN_PATH_HINT ${WONDERFUL_TOOLCHAIN}/toolchain/gcc-${BLOCKSDS_TRIPLET}/bin)
+find_program(CMAKE_ASM_COMPILER ${BLOCKSDS_TRIPLET}-gcc        HINTS ${TOOLCHAIN_PATH_HINT})
+find_program(CMAKE_C_COMPILER   ${BLOCKSDS_TRIPLET}-gcc        HINTS ${TOOLCHAIN_PATH_HINT})
+find_program(CMAKE_CXX_COMPILER ${BLOCKSDS_TRIPLET}-g++        HINTS ${TOOLCHAIN_PATH_HINT})
+find_program(CMAKE_LINKER       ${BLOCKSDS_TRIPLET}-ld         HINTS ${TOOLCHAIN_PATH_HINT})
+find_program(CMAKE_AR           ${BLOCKSDS_TRIPLET}-gcc-ar     HINTS ${TOOLCHAIN_PATH_HINT})
+find_program(CMAKE_RANLIB       ${BLOCKSDS_TRIPLET}-gcc-ranlib HINTS ${TOOLCHAIN_PATH_HINT})
+find_program(CMAKE_STRIP        ${BLOCKSDS_TRIPLET}-strip      HINTS ${TOOLCHAIN_PATH_HINT})
+
+find_program(BLOCKSDS_NDSTOOL NAMES ndstool HINTS "${BLOCKSDS}/tools/ndstool")
+
+
+
+# post-link utilities to create NDS rom
+function(nds_create_rom target)
+    cmake_parse_arguments(PARSE_ARGV 1 NDSTOOL "" "OUTPUT;ARM9;ARM7;NAME;SUBTITLE;AUTHOR;ICON;NITROFS;SUBTITLE1;SUBTITLE2" "FLAGS")
+
+    if(NOT BLOCKSDS_NDSTOOL)
+        message(FATAL_ERROR "Could not find ndstool: try installing ndstool")
+    endif()
+
+    if(NOT TARGET "${target}")
+        message(FATAL_ERROR "nds_create_rom: target '${target}' not defined")
+    endif()
+
+    if(DEFINED NDSTOOL_ARM9)
+        message(FATAL_ERROR "nds_create_rom: custom ARM9 elf not supported")
+    endif()
+
+
+    # resolve output rom filename
+    get_target_property(target_dir ${target} BINARY_DIR)
+    get_target_property(target_filename ${target} OUTPUT_NAME)
+    if(NOT target_filename)
+        set(target_filename "${target}")
+    endif()
+
+    set(NDSTOOL_OUTPUT "${target_dir}/${target_filename}.nds")
+
+
+    # resolve input ARM7 elf file
+    if(NOT DEFINED NDSTOOL_ARM7)
+        set(NDSTOOL_ARM7 "${BLOCKSDS}/sys/default_arm7/arm7.elf")
+    endif()
+
+
+    # resolve details (NAME/SUBTITLE/AUTHOR) for ndstool
+    if (NOT DEFINED NDSTOOL_NAME)
+        set(NDSTOOL_NAME "${CMAKE_PROJECT_NAME}")
+    endif()
+
+    if (NOT DEFINED NDSTOOL_SUBTITLE AND DEFINED NDSTOOL_SUBTITLE1)
+        set(NDSTOOL_SUBTITLE "${NDSTOOL_SUBTITLE1}")
+    elseif (NOT DEFINED NDSTOOL_SUBTITLE)
+        set(NDSTOOL_SUBTITLE "Built with BlocksDS")
+    endif()
+
+    if (NOT DEFINED NDSTOOL_AUTHOR AND DEFINED NDSTOOL_SUBTITLE2)
+        set(NDSTOOL_AUTHOR "${NDSTOOL_SUBTITLE2}")
+    elseif (NOT DEFINED NDSTOOL_AUTHOR)
+        set(NDSTOOL_AUTHOR "github.com/blocksds/sdk")
+    endif()
+
+
+    # resolve icon
+    if (NOT DEFINED NDSTOOL_ICON)
+        find_file(NDSTOOL_ICON NAMES icon.bmp HINTS "${BLOCKSDS}/sys")
+
+        if(NOT NDSTOOL_ICON)
+            message(FATAL_ERROR "nds_create_rom: could not find default icon, try installing libnds")
+        endif()
+    elseif(TARGET "${NDSTOOL_ICON}")
+        message(FATAL_ERROR "nds_create_rom: ICON must be a file and not a target")
+    else()
+        get_filename_component(NDSTOOL_ICON "${NDSTOOL_ICON}" ABSOLUTE)
+
+        if(NOT EXISTS "${NDSTOOL_ICON}")
+            message(FATAL_ERROR "nds_create_rom: cannot find ICON [${NDSTOOL_ICON}]")
+        endif()
+    endif()
+
+
+    # prepare ndstool invocation
+    set(NDSTOOL_DEPS ${target} "${NDSTOOL_ARM7}")
+
+    set(NDSTOOL_ARGS
+        -c "${NDSTOOL_OUTPUT}"
+        -9 "$<TARGET_FILE:${target}>"
+        -7 "${NDSTOOL_ARM7}"
+        -b "${NDSTOOL_ICON}"
+        "${NDSTOOL_NAME}\;${NDSTOOL_SUBTITLE}\;${NDSTOOL_AUTHOR}")
+
+    if (DEFINED NDSTOOL_FLAGS)
+        list(APPEND NDSTOOL_ARGS ${NDSTOOL_FLAGS})
+    endif()
+
+
+    # add nitrofs if present
+    if (DEFINED NDSTOOL_NITROFS)
+        get_filename_component(NDSTOOL_NITROFS "${NDSTOOL_NITROFS}" ABSOLUTE)
+
+        if (NOT IS_DIRECTORY "${NDSTOOL_NITROFS}")
+            message(FATAL_ERROR "nds_create_rom: NITROFS must be a directory [${NDSTOOL_NITROFS}]")
+        endif()
+
+        list(APPEND NDSTOOL_ARGS -d "${NDSTOOL_NITROFS}")
+    endif()
+
+
+    # invoke ndstool
+    add_custom_command(
+        OUTPUT "${NDSTOOL_OUTPUT}"
+        COMMAND "${BLOCKSDS_NDSTOOL}" ${NDSTOOL_ARGS}
+        DEPENDS ${target} "${NDSTOOL_ARM7}"
+        COMMENT "Building NDS ROM target ${outtarget}"
+        VERBATIM
+    )
+
+    add_custom_target(${target}_nds ALL DEPENDS "${NDSTOOL_OUTPUT}")
+endfunction()

--- a/sys/cmake/BlocksDSi.cmake
+++ b/sys/cmake/BlocksDSi.cmake
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: ds-sloth, 2024
+
+cmake_minimum_required(VERSION 3.16)
+
+set(NDS_DSI_EXCLUSIVE ON)
+
+include(${CMAKE_CURRENT_LIST_DIR}/BlocksDS.cmake)

--- a/sys/cmake/Platform/NintendoDS.cmake
+++ b/sys/cmake/Platform/NintendoDS.cmake
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: ds-sloth, 2024
+
+cmake_minimum_required(VERSION 3.16)
+
+# set default build configs to standard values
+set(CMAKE_BUILD_TYPE_INIT "Release")
+set(CMAKE_EXECUTABLE_SUFFIX ".elf")
+set(BUILD_SHARED_LIBS OFF CACHE INTERNAL "Dynamic libraries are unsupported on BlocksDS")
+set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS FALSE)
+
+
+
+# set up compiler and linker options
+set(STANDARD_INCLUDE_DIRECTORIES "${BLOCKSDS}/libs/dswifi/include" "${BLOCKSDS}/libs/libteak/include" "${BLOCKSDS}/libs/libxm7/include" "${BLOCKSDS}/libs/maxmod/include" "${BLOCKSDS}/libs/libnds/include")
+set(ARCH_FLAGS "-march=armv5te -mcpu=arm946e-s+nofp -mtune=arm946e-s")
+set(STANDARD_FLAGS  "-ffunction-sections -fdata-sections -D__NDS__ -DARM9")
+set(LINKER_FLAGS  "-L${BLOCKSDS}/libs/dswifi/lib -L{BLOCKSDS}/libs/libteak/lib -L${BLOCKSDS}/libs/libxm7/lib -L${BLOCKSDS}/libs/maxmod/lib -L${BLOCKSDS}/libs/libnds/lib")
+set(STANDARD_LIBRARIES "-lnds9 -lstdc++ -lc")
+
+if(NDS_DSI_EXCLUSIVE)
+    set(LINKER_FLAGS "${LINKER_FLAGS} -specs=${BLOCKSDS}/sys/crts/dsi_arm9.specs")
+else()
+    set(LINKER_FLAGS "${LINKER_FLAGS} -specs=${BLOCKSDS}/sys/crts/ds_arm9.specs")
+endif()
+
+if(NDS_ARCH_THUMB)
+    set(ARCH_FLAGS "${ARCH_FLAGS} -mthumb")
+endif()
+
+
+# apply flags
+foreach(LANG IN ITEMS C CXX ASM)
+    set(CMAKE_${LANG}_FLAGS_INIT "${ARCH_FLAGS} ${STANDARD_FLAGS}")
+
+    set(CMAKE_${LANG}_STANDARD_LIBRARIES "${STANDARD_LIBRARIES}" CACHE STRING "" FORCE)
+    set(CMAKE_${LANG}_STANDARD_INCLUDE_DIRECTORIES "${STANDARD_INCLUDE_DIRECTORIES}" CACHE STRING "")
+endforeach()
+
+set(CMAKE_ASM_FLAGS_INIT "${CMAKE_ASM_FLAGS_INIT} -x assembler-with-cpp")
+
+set(CMAKE_EXE_LINKER_FLAGS_INIT "${ARCH_FLAGS} ${LINKER_FLAGS}")

--- a/sys/cmake/README.md
+++ b/sys/cmake/README.md
@@ -1,0 +1,33 @@
+## BlocksDS CMake
+
+BlocksDS provides simple CMake build scripts for cross-platform projects. These build scripts allow developers to build their applications for the DS/DSi and create a rom using the default ARM7 binary.
+
+### Usage
+
+Add `-DCMAKE_TOOLCHAIN_FILE=$BLOCKSDS/cmake/BlocksDS.cmake` (or `BlocksDSi.cmake`) to your `cmake` invocation to set up your project to build an ARM9 binary for the DS(i).
+
+This will define CMake variables `BLOCKSDS` (a path to the BLOCKSDS core directory), `NINTENDO_DS`, and (possibly) `NDS_DSI_EXCLUSIVE`. Your project may make use of these variables to add NDS-specific source files to your build.
+
+#### nds_create_rom
+The toolchain file provides a new CMake function `nds_create_rom`. This takes your main executable target as well as arguments specifying the NDS header. All arguments are optional. An example:
+
+```
+nds_create_rom(my_target
+    NAME "My Cool Game"
+    SUBTITLE "An Example Project"
+    AUTHOR "Me, Myself, and I"
+    ICON "${CMAKE_CURRENT_SOURCE_DIR}/nds-icon.bmp"
+    ARM7 "${CMAKE_CURRENT_SOURCE_DIR}/arm7.elf"
+    NITROFS "${CMAKE_CURRENT_SOURCE_DIR}/nitrofs-dir"
+)
+```
+
+#### Toolchain file selection
+The only difference between `BlocksDS.cmake` and `BlocksDSi.cmake` is that the latter allows the entire memory space of the DSi to be used by the main program's code and statically-allocated variables. Otherwise, only ~3.5MB are available. Note that including an ARM9 binary above 2.5MB violates the NDS ROM standard and such roms may fail to boot in some menus.
+
+#### Toolchain variables
+Currently the BlocksDS toolchain file accepts the following variables. They should be set in the initial `cmake` invocation. 
+
+* `NDS_ARCH_THUMB`: if this flag is set, then all code will be generated for the thumb instruction set.
+
+The toolchain file also checks the local environment variables `BLOCKSDS` to locate the BlocksDS core directory and `WONDERFUL_TOOLCHAIN` to locate the Wonderful root directory.


### PR DESCRIPTION
Here are my CMake build scripts. Fully rewritten but aimed at compatibility with existing projects targeting devkitPro CMake. ARM9 only since the aim is to facilitate cross-platform projects, not NDS-specific development.

This PR should not be merged until it has a Makefile to add these new files to the installation process.