### PR TITLE
NintendoDS.cmake: patch circular dependency link issue

### DIFF
--- a/sys/cmake/Platform/NintendoDS.cmake
+++ b/sys/cmake/Platform/NintendoDS.cmake
@@ -17,7 +17,7 @@ set(STANDARD_INCLUDE_DIRECTORIES "${BLOCKSDS}/libs/dswifi/include" "${BLOCKSDS}/
 set(ARCH_FLAGS "-march=armv5te -mcpu=arm946e-s+nofp -mtune=arm946e-s")
 set(STANDARD_FLAGS  "-ffunction-sections -fdata-sections -D__NDS__ -DARM9")
 set(LINKER_FLAGS  "-L${BLOCKSDS}/libs/dswifi/lib -L{BLOCKSDS}/libs/libteak/lib -L${BLOCKSDS}/libs/libxm7/lib -L${BLOCKSDS}/libs/maxmod/lib -L${BLOCKSDS}/libs/libnds/lib")
-set(STANDARD_LIBRARIES "-lnds9 -lstdc++ -lc")
+set(STANDARD_LIBRARIES "-lc -lnds9 -lstdc++ -lc")
 
 if(NDS_DSI_EXCLUSIVE)
     set(LINKER_FLAGS "${LINKER_FLAGS} -specs=${BLOCKSDS}/sys/crts/dsi_arm9.specs")


### PR DESCRIPTION
This should fix the issue regarding a circular dependency between picolibc and libnds9 recently discussed on Discord.