### PR TITLE
CMake: Use linker group for standard libraries

### DIFF
--- a/sys/cmake/Platform/NintendoDS.cmake
+++ b/sys/cmake/Platform/NintendoDS.cmake
@@ -17,7 +17,7 @@ set(STANDARD_INCLUDE_DIRECTORIES "${BLOCKSDS}/libs/dswifi/include" "${BLOCKSDS}/
 set(ARCH_FLAGS "-march=armv5te -mcpu=arm946e-s+nofp -mtune=arm946e-s")
 set(STANDARD_FLAGS  "-ffunction-sections -fdata-sections -D__NDS__ -DARM9")
 set(LINKER_FLAGS  "-L${BLOCKSDS}/libs/dswifi/lib -L{BLOCKSDS}/libs/libteak/lib -L${BLOCKSDS}/libs/libxm7/lib -L${BLOCKSDS}/libs/maxmod/lib -L${BLOCKSDS}/libs/libnds/lib")
-set(STANDARD_LIBRARIES "-lc -lnds9 -lstdc++ -lc")
+set(STANDARD_LIBRARIES "-Wl,--start-group -lnds9 -lstdc++ -lc -Wl,--end-group")
 
 if(NDS_DSI_EXCLUSIVE)
     set(LINKER_FLAGS "${LINKER_FLAGS} -specs=${BLOCKSDS}/sys/crts/dsi_arm9.specs")


### PR DESCRIPTION
The `portable_demo` CMake example doesn't build currently. I get a complaint from the linker:
```
/opt/wonderful/toolchain/gcc-arm-none-eabi/lib/gcc/arm-none-eabi/14.2.0/../../../../arm-none-eabi/bin/ld: /opt/wonderful/toolchain/gcc-arm-none-eabi/lib/gcc/arm-none-eabi/14.2.0/../../../../arm-none-eabi/lib/thumb/arm946e-s/libc.a(libc_time_time.c.o): in function `time':
/wf/packages/toolchain-gcc-arm-none-eabi-picolibc-generic/src/picolibc-build/../wf-picolibc/newlib/libc/time/time.c:54:(.text.time+0x8): undefined reference to `gettimeofday'
collect2: error: ld returned 1 exit status
```
Removing the first `-lc` from `STANDARD_LIBRARIES` in the platform file fixes this. I understand this was put in to address a circular dependency issue (#241) so I've opted to instead just use `--start-group`/`--end-group` which should still work for whatever was having issues before.