### PR TITLE
WIP: Add initial dynamic library support

### DIFF
--- a/examples/dynamic_libs/Makefile
+++ b/examples/dynamic_libs/Makefile
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: Antonio Niño Díaz, 2023
+
+.PHONY: all clean
+
+MAKE	:= make
+
+all:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile ; then \
+			$(MAKE) -C $$i --no-print-directory || { exit 1;} \
+		fi; \
+	done;
+
+clean:
+	@for i in `ls`; do \
+		if test -e $$i/Makefile ; then \
+			$(MAKE) -C $$i clean --no-print-directory || { exit 1;} \
+		fi; \
+	done;

--- a/examples/dynamic_libs/basic_demo/.gitignore
+++ b/examples/dynamic_libs/basic_demo/.gitignore
@@ -1,0 +1,4 @@
+*.elf
+*.dsl
+*.nds
+build/

--- a/examples/dynamic_libs/basic_demo/Makefile
+++ b/examples/dynamic_libs/basic_demo/Makefile
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: Antonio Niño Díaz, 2025
+
+BLOCKSDS	?= /opt/blocksds/core
+
+# User config
+
+NAME		:= dyn_libs_basic_demo
+GAME_TITLE	:= Basic demo
+GAME_SUBTITLE	:= Dynamic libraries
+
+# Source code paths
+
+INCLUDEDIRS	:= source
+NITROFSDIR	:= nitrofs
+
+include $(BLOCKSDS)/sys/default_makefiles/rom_arm9/Makefile

--- a/examples/dynamic_libs/basic_demo/build.sh
+++ b/examples/dynamic_libs/basic_demo/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# TODO: Replace this by a real build system
+
+set -e
+
+BLOCKSDS="${BLOCKSDS:-/opt/blocksds/core}"
+
+pushd lib_calculator
+make clean
+make
+popd
+
+rm -rf nitrofs
+mkdir nitrofs
+
+make build/dyn_libs_basic_demo.elf
+
+${BLOCKSDS}/tools/dsltool/dsltool \
+    -i lib_calculator/calculator.elf \
+    -o nitrofs/calculator.dsl \
+    -m build/dyn_libs_basic_demo.elf
+
+make clean
+make

--- a/examples/dynamic_libs/basic_demo/lib_calculator/Makefile
+++ b/examples/dynamic_libs/basic_demo/lib_calculator/Makefile
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: Antonio Niño Díaz, 2023-2025
+
+export BLOCKSDS			?= /opt/blocksds/core
+export BLOCKSDSEXT		?= /opt/blocksds/external
+
+export WONDERFUL_TOOLCHAIN	?= /opt/wonderful
+ARM_NONE_EABI_PATH	?= $(WONDERFUL_TOOLCHAIN)/toolchain/gcc-arm-none-eabi/bin/
+
+# Source code paths
+# -----------------
+
+SOURCEDIRS	:= source
+INCLUDEDIRS	:= include
+GFXDIRS		:=
+BINDIRS		:=
+
+# Defines passed to all files
+# ---------------------------
+
+DEFINES		:= -DSAMPLE_DEFINE -DSAMPLE_DEFINE_WITH_VALUE=123
+
+# Libraries
+# ---------
+
+LIBDIRS		:=
+
+# Build artifacts
+# ---------------
+
+NAME		:= calculator
+BUILDDIR	:= build/$(NAME)
+LIBRARY		:= $(NAME).elf
+
+# Tools
+# -----
+
+PREFIX		:= $(ARM_NONE_EABI_PATH)arm-none-eabi-
+CC		:= $(PREFIX)gcc
+CXX		:= $(PREFIX)g++
+AR		:= $(PREFIX)gcc-ar
+MKDIR		:= mkdir
+RM		:= rm -rf
+CP		:= cp
+
+# Verbose flag
+# ------------
+
+ifeq ($(VERBOSE),1)
+V		:=
+else
+V		:= @
+endif
+
+# Source files
+# ------------
+
+ifneq ($(BINDIRS),)
+    SOURCES_BIN	:= $(shell find -L $(BINDIRS) -name "*.bin")
+    INCLUDEDIRS	+= $(addprefix $(BUILDDIR)/,$(BINDIRS))
+endif
+ifneq ($(GFXDIRS),)
+    SOURCES_PNG	:= $(shell find -L $(GFXDIRS) -name "*.png")
+    INCLUDEDIRS	+= $(addprefix $(BUILDDIR)/,$(GFXDIRS))
+endif
+
+SOURCES_S	:= $(shell find -L $(SOURCEDIRS) -name "*.s")
+SOURCES_C	:= $(shell find -L $(SOURCEDIRS) -name "*.c")
+SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
+
+# Compiler and linker flags
+# -------------------------
+
+ARCH		:= -mthumb -mcpu=arm946e-s+nofp
+#ARCH		:= -mthumb -mcpu=arm7tdmi
+
+SPECS		:= $(BLOCKSDS)/sys/crts/ds_arm9.specs
+
+WARNFLAGS	:= -Wall
+
+INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
+		   $(foreach path,$(LIBDIRS),-I$(path)/include)
+
+ASFLAGS		+= -x assembler-with-cpp $(DEFINES) $(INCLUDEFLAGS) \
+		   $(ARCH) -ffunction-sections -fdata-sections \
+		   -fvisibility=hidden #-specs=$(SPECS)
+
+CFLAGS		+= -std=gnu17 $(WARNFLAGS) $(DEFINES) $(INCLUDEFLAGS) \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
+		   -fvisibility=hidden #-specs=$(SPECS)
+
+CXXFLAGS	+= -std=gnu++17 $(WARNFLAGS) $(DEFINES) $(INCLUDEFLAGS) \
+		   $(ARCH) -O2 -ffunction-sections -fdata-sections \
+		   -fno-exceptions -fno-rtti \
+		   -fvisibility=hidden #-specs=$(SPECS)
+
+# Intermediate build files
+# ------------------------
+
+OBJS_ASSETS	:= $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_BIN))) \
+		   $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_PNG)))
+
+HEADERS_ASSETS	:= $(patsubst %.bin,%_bin.h,$(addprefix $(BUILDDIR)/,$(SOURCES_BIN))) \
+		   $(patsubst %.png,%.h,$(addprefix $(BUILDDIR)/,$(SOURCES_PNG)))
+
+OBJS_SOURCES	:= $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_S))) \
+		   $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_C))) \
+		   $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_CPP)))
+
+OBJS		:= $(OBJS_ASSETS) $(OBJS_SOURCES)
+
+DEPS		:= $(OBJS:.o=.d)
+
+# Targets
+# -------
+
+.PHONY: all clean
+
+all: $(LIBRARY)
+
+$(LIBRARY): $(OBJS)
+	@echo "  LD      $@"
+	@$(MKDIR) -p $(@D)
+	$(V)$(CC) -nostdlib \
+		-Wl,--emit-relocs -Wl,--unresolved-symbols=ignore-all -Wl,--nmagic \
+		-T dsl.ld -o $@ $(OBJS)
+
+clean:
+	@echo "  CLEAN"
+	$(V)$(RM) $(LIBRARY) build $(BUILDDIR)
+
+# Rules
+# -----
+
+$(BUILDDIR)/%.s.o : %.s
+	@echo "  AS      $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(CC) $(ASFLAGS) -MMD -MP -c -o $@ $<
+
+$(BUILDDIR)/%.c.o : %.c
+	@echo "  CC      $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(CC) $(CFLAGS) -MMD -MP -c -o $@ $<
+
+$(BUILDDIR)/%.arm.c.o : %.arm.c
+	@echo "  CC      $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(CC) $(CFLAGS) -MMD -MP -marm -mlong-calls -c -o $@ $<
+
+$(BUILDDIR)/%.cpp.o : %.cpp
+	@echo "  CXX     $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(CXX) $(CXXFLAGS) -MMD -MP -c -o $@ $<
+
+$(BUILDDIR)/%.arm.cpp.o : %.arm.cpp
+	@echo "  CXX     $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(CXX) $(CXXFLAGS) -MMD -MP -marm -mlong-calls -c -o $@ $<
+
+$(BUILDDIR)/%.bin.o $(BUILDDIR)/%_bin.h : %.bin
+	@echo "  BIN2C   $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(BLOCKSDS)/tools/bin2c/bin2c $< $(@D)
+	$(V)$(CC) $(CFLAGS) -MMD -MP -c -o $(BUILDDIR)/$*.bin.o $(BUILDDIR)/$*_bin.c
+
+$(BUILDDIR)/%.png.o $(BUILDDIR)/%.h : %.png %.grit
+	@echo "  GRIT    $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(BLOCKSDS)/tools/grit/grit $< -ftc -W1 -o$(BUILDDIR)/$*
+	$(V)$(CC) $(CFLAGS) -MMD -MP -c -o $(BUILDDIR)/$*.png.o $(BUILDDIR)/$*.c
+	$(V)touch $(BUILDDIR)/$*.png.o $(BUILDDIR)/$*.h
+
+# All assets must be built before the source code
+# -----------------------------------------------
+
+$(SOURCES_S) $(SOURCES_C) $(SOURCES_CPP): $(HEADERS_ASSETS)
+
+# Include dependency files if they exist
+# --------------------------------------
+
+-include $(DEPS)

--- a/examples/dynamic_libs/basic_demo/lib_calculator/dsl.ld
+++ b/examples/dynamic_libs/basic_demo/lib_calculator/dsl.ld
@@ -1,0 +1,27 @@
+/*
+ * SPDX-License-Identifier: Zlib
+ *
+ * Copyright (C) 2025 Antonio Niño Díaz
+ */
+
+OUTPUT_FORMAT("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
+OUTPUT_ARCH(arm)
+
+SECTIONS
+{
+    .progbits ALIGN(4) :
+    {
+        *(.text*);
+        . = ALIGN(4);
+        *(.rodata*);
+        . = ALIGN(4);
+        *(.data*);
+        . = ALIGN(4);
+    }
+
+    .nobits ALIGN(4) (NOLOAD) :
+    {
+        *(.bss* COMMON);
+        . = ALIGN(4);
+    }
+}

--- a/examples/dynamic_libs/basic_demo/lib_calculator/source/calculator.c
+++ b/examples/dynamic_libs/basic_demo/lib_calculator/source/calculator.c
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: Antonio Niño Díaz, 2025
+
+#include <stdio.h>
+#include <stddef.h>
+
+#define SYM_PUBLIC  __attribute__((visibility ("default")))
+#define SYM_LOCAL   __attribute__((visibility ("hidden")))
+#define ARM_CODE    __attribute__((target("arm")))
+
+static int array_1[6] = { 1000, 900, 800, 700, 600, 500 };
+
+static int array_2[6] = { 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF };
+
+typedef int (*fpointer)(int, int);
+
+fpointer operation_fn;
+
+__attribute__((noinline)) int add(int a, int b)
+{
+    return a + b;
+}
+
+int op_add(int a, int b)
+{
+    // Test that we can call a function from another function within the library
+    return add(a, b);
+}
+
+int op_sub(int a, int b)
+{
+    return a - b;
+}
+
+int op_mul(int a, int b)
+{
+    return a * b;
+}
+
+int op_div(int a, int b)
+{
+    // Division requires libgcc
+    return a / b;
+}
+
+int op_array_1(int a, int b)
+{
+    if (a < 0 || a >= 6)
+        return -1;
+
+    return array_1[a];
+}
+
+int op_array_2(int a, int b)
+{
+    if (a < 0 || a >= 6)
+        return -1;
+
+    // Test that we can call printf() from the main binary
+    printf("printf from %s(%d, %d)\n", __func__, a, b);
+
+    return array_2[a];
+}
+
+SYM_PUBLIC int operation_run(int a, int b)
+{
+    if (operation_fn == NULL)
+        return 0;
+
+    return operation_fn(a, b);
+}
+
+SYM_PUBLIC int operation_set(int id)
+{
+    if ((id < 0) || (id >= 6))
+        operation_fn = NULL;
+
+    fpointer ptrs[6] = {
+        op_add, op_sub, op_mul, op_div, op_array_1, op_array_2
+    };
+
+    operation_fn = ptrs[id];
+
+    return 0;
+}
+
+ARM_CODE SYM_PUBLIC int operation_arm(int value)
+{
+    // Test that we can call ARM and Thumb functions from ARM code. The division
+    // will be replaced by a libgcc call by the compiler.
+    int res = 333 / value;
+
+    printf("printf from %s(%d)\n"
+           "    333 / %d = %d\n",
+           __func__, value, value, res);
+
+    return res;
+}

--- a/examples/dynamic_libs/basic_demo/source/main.c
+++ b/examples/dynamic_libs/basic_demo/source/main.c
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: CC0-1.0
+//
+// SPDX-FileContributor: Antonio Niño Díaz, 2025
+
+#include <stdio.h>
+
+#include <filesystem.h>
+#include <nds.h>
+
+#include "dlfcn.h"
+
+
+void wait_forever(void)
+{
+    while (1)
+        swiWaitForVBlank();
+}
+
+typedef int (fnptr1int)(int);
+typedef int (fnptr2int)(int, int);
+
+int main(int argc, char **argv)
+{
+    defaultExceptionHandler();
+
+    PrintConsole topScreen;
+    PrintConsole bottomScreen;
+
+    videoSetMode(MODE_0_2D);
+    videoSetModeSub(MODE_0_2D);
+
+    vramSetBankA(VRAM_A_MAIN_BG);
+    vramSetBankC(VRAM_C_SUB_BG);
+
+    consoleInit(&topScreen, 3, BgType_Text4bpp, BgSize_T_256x256, 31, 0, true, true);
+    consoleInit(&bottomScreen, 3, BgType_Text4bpp, BgSize_T_256x256, 31, 0, false, true);
+
+    consoleSelect(&topScreen);
+
+    bool init_ok = nitroFSInit(NULL);
+    if (!init_ok)
+    {
+        perror("nitroFSInit()");
+        wait_forever();
+    }
+
+    // Use bright green
+
+    printf("Loading library...\n");
+
+    void *h = dlopen("calculator.dsl", RTLD_NOW | RTLD_LOCAL);
+    const char *err = dlerror();
+    if (err != NULL)
+    {
+        printf("dlopen(): %s\n", err);
+        wait_forever();
+    }
+
+    printf("Resolving public functions...\n");
+    printf("\n");
+
+    fnptr1int *operation_set = dlsym(h, "operation_set");
+    printf("operation_set: %p\n", operation_set);
+    err = dlerror();
+    if (err != NULL)
+    {
+        printf("dlsym(operation_set): %s\n", err);
+        wait_forever();
+    }
+
+    fnptr2int *operation_run = dlsym(h, "operation_run");
+    printf("operation_run: %p\n", operation_run);
+    err = dlerror();
+    if (err != NULL)
+    {
+        printf("dlsym(operation_run): %s\n", err);
+        wait_forever();
+    }
+    fnptr1int *operation_arm = dlsym(h, "operation_arm");
+    printf("operation_arm: %p\n", operation_arm);
+    err = dlerror();
+    if (err != NULL)
+    {
+        printf("dlsym(operation_arm): %s\n", err);
+        wait_forever();
+    }
+    printf("\n");
+
+    printf("Using library functions...\n");
+    printf("\n");
+    operation_set(0);
+    printf("123 + 456 = %d\n", operation_run(123, 456));
+    operation_set(1);
+    printf("123 - 456 = %d\n", operation_run(123, 456));
+    operation_set(2);
+    printf("123 * 456 = %d\n", operation_run(123, 456));
+    operation_set(3);
+    printf("900 / 70 = %d\n", operation_run(900, 70));
+    operation_set(4);
+    printf("arr1[2] = %d\n", operation_run(2, 0));
+    printf("arr1[3] = %d\n", operation_run(3, 0));
+    operation_set(5);
+    printf("arr2[2] = 0x%X\n", operation_run(2, 0));
+    printf("arr2[3] = 0x%X\n", operation_run(3, 0));
+    printf("\n");
+
+    consoleSelect(&bottomScreen);
+
+    printf("Calling operation_arm(5)...\n");
+    int res = operation_arm(5);
+    printf("Result = %d\n", res);
+    printf("\n");
+
+    // This should fail
+    printf("Resolving private symbol...\n");
+    void *ptr = dlsym(h, "op_add");
+    printf("dlsym(op_add): %p\n", ptr);
+    if (ptr != NULL)
+    {
+        printf("This should have failed!");
+        wait_forever();
+    }
+    err = dlerror();
+    if (err == NULL)
+    {
+        printf("This should have returned an error!\n");
+        wait_forever();
+    }
+    printf("\n");
+
+    printf("Unloading library...\n");
+
+    dlclose(h);
+    err = dlerror();
+    if (err != NULL)
+    {
+        printf("dlclose(): %s\n", err);
+        wait_forever();
+    }
+
+    printf("Press START to exit to loader\n");
+
+    while (1)
+    {
+        swiWaitForVBlank();
+
+        scanKeys();
+
+        if (keysHeld() & KEY_START)
+            break;
+    }
+
+    return 0;
+}

--- a/examples/dynamic_libs/readme.md
+++ b/examples/dynamic_libs/readme.md
@@ -1,0 +1,6 @@
+# BlocksDS SDK examples: Dynamic libraries
+
+This folder contains examples of how to load modules such as dynamic libraries
+at runtime.
+
+- `basic_demo`: It loads a simple library and uses it to prove everything works.

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -14,6 +14,7 @@ specific area:
 - `demos`: Simple "completed" games, designed to be used as reference.
 - `dsp`: Examples of how to use the DSP of the DSi.
 - `dswifi`: DSWiFi library features.
+- `dynamic_libs`: How to load dynamic libraries with libnds.
 - `filesystem`: How to access the 3 filesystems of the DS/DSi.
 - `gl2d`: How to use the GL2D library for 2D graphics with the 3D hardware.
 - `graphics_2d`: 2D graphics features of the DS.

--- a/tools/dsltool/.gitignore
+++ b/tools/dsltool/.gitignore
@@ -1,0 +1,2 @@
+dsltool
+build

--- a/tools/dsltool/COPYING
+++ b/tools/dsltool/COPYING
@@ -1,0 +1,21 @@
+zlib License
+
+Copyright (c) 2025 Antonio Niño Díaz
+
+This software is provided 'as-is', without any express or implied warranty. In
+no event will the authors be held liable for any damages arising from the use of
+this software.
+
+Permission is granted to anyone to use this software for any purpose, including
+commercial applications, and to alter it and redistribute it freely, subject to
+the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not claim
+   that you wrote the original software. If you use this software in a product,
+   an acknowledgment in the product documentation would be appreciated but is
+   not required.
+
+2. Altered source versions must be plainly marked as such, and must not be
+   misrepresented as being the original software.
+
+3. This notice may not be removed or altered from any source distribution.

--- a/tools/dsltool/Makefile
+++ b/tools/dsltool/Makefile
@@ -1,0 +1,132 @@
+# SPDX-License-Identifier: CC0-1.0
+#
+# SPDX-FileContributor: Antonio Niño Díaz, 2023-2025
+
+# Source code paths
+# -----------------
+
+SOURCEDIRS	:= source
+INCLUDEDIRS	:= source
+
+# Defines passed to all files
+# ---------------------------
+
+DEFINES		:= -DPACKAGE_VERSION=\"1.0.0\"
+
+# Libraries
+# ---------
+
+LIBS		:=
+LIBDIRS		:=
+
+# Build artifacts
+# ---------------
+
+NAME		:= dsltool
+BUILDDIR	:= build
+ELF		:= $(NAME)
+
+# Tools
+# -----
+
+STRIP		:= -s
+BINMODE		:= 755
+
+HOSTCC		?= gcc
+HOSTCXX		?= g++
+CP		:= cp
+MKDIR		:= mkdir
+RM		:= rm -rf
+MAKE		:= make
+INSTALL		:= install
+
+# Verbose flag
+# ------------
+
+ifeq ($(VERBOSE),1)
+V		:=
+else
+V		:= @
+endif
+
+# Source files
+# ------------
+
+SOURCES_C	:= $(shell find -L $(SOURCEDIRS) -name "*.c")
+SOURCES_CPP	:= $(shell find -L $(SOURCEDIRS) -name "*.cpp")
+
+# Compiler and linker flags
+# -------------------------
+
+WARNFLAGS_C	:= -Wall -Wextra -Wstrict-prototypes
+
+WARNFLAGS_CXX	:= -Wall -Wextra
+
+ifeq ($(SOURCES_CPP),)
+    HOSTLD	:= $(HOSTCC)
+else
+    HOSTLD	:= $(HOSTCXX)
+endif
+
+INCLUDEFLAGS	:= $(foreach path,$(INCLUDEDIRS),-I$(path)) \
+		   $(foreach path,$(LIBDIRS),-I$(path)/include)
+
+LIBDIRSFLAGS	:= $(foreach path,$(LIBDIRS),-L$(path)/lib)
+
+CFLAGS		+= -std=gnu11 $(WARNFLAGS_C) $(DEFINES) $(INCLUDEFLAGS) -O3
+
+CXXFLAGS	+= -std=gnu++14 $(WARNFLAGS_CXX) $(DEFINES) $(INCLUDEFLAGS) -O3
+
+LDFLAGS		:= $(LIBDIRSFLAGS) $(LIBS)
+
+# Intermediate build files
+# ------------------------
+
+OBJS		:= $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_C))) \
+		   $(addsuffix .o,$(addprefix $(BUILDDIR)/,$(SOURCES_CPP)))
+
+DEPS		:= $(OBJS:.o=.d)
+
+# Targets
+# -------
+
+.PHONY: all clean install
+
+all: $(ELF)
+
+$(ELF): $(OBJS)
+	@echo "  HOSTLD  $@"
+	$(V)$(HOSTLD) -o $@ $(OBJS) $(LDFLAGS)
+
+clean:
+	@echo "  CLEAN  "
+	$(V)$(RM) $(ELF) $(BUILDDIR)
+
+INSTALLDIR	?= /opt/blocksds/core/tools/dsltool
+INSTALLDIR_ABS	:= $(abspath $(INSTALLDIR))
+
+install: all
+	@echo "  INSTALL $(INSTALLDIR_ABS)"
+	@test $(INSTALLDIR_ABS)
+	$(V)$(RM) $(INSTALLDIR_ABS)
+	$(V)$(INSTALL) -d $(INSTALLDIR_ABS)
+	$(V)$(INSTALL) $(STRIP) -m $(BINMODE) $(NAME) $(INSTALLDIR_ABS)
+	$(V)$(CP) ./COPYING $(INSTALLDIR_ABS)
+
+# Rules
+# -----
+
+$(BUILDDIR)/%.c.o : %.c
+	@echo "  HOSTCC  $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(HOSTCC) $(CFLAGS) -MMD -MP -c -o $@ $<
+
+$(BUILDDIR)/%.cpp.o : %.cpp
+	@echo "  HOSTCXX $<"
+	@$(MKDIR) -p $(@D)
+	$(V)$(HOSTCXX) $(CXXFLAGS) -MMD -MP -c -o $@ $<
+
+# Include dependency files if they exist
+# --------------------------------------
+
+-include $(DEPS)

--- a/tools/dsltool/source/dsl.h
+++ b/tools/dsltool/source/dsl.h
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2025 Antonio Niño Díaz
+
+#ifndef LIBNDS_DSL_H__
+#define LIBNDS_DSL_H__
+
+#include <assert.h>
+#include <stdint.h>
+
+/// DSL (Nintendo DS Loadable Format) description and helpers.
+///
+/// DSL is a format for shared libraries that can be loaded with BlocksDS. It is
+/// a simplified version of the ELF format used in .so files.
+///
+/// General structure of the file:
+///
+///     +======================+
+///     | DSL header           | It specifies the number of sections in the file.
+///     +======================+
+///     | DSL section header 0 | As many section headers as sections.
+///     +----------------------+
+///     | DSL section header 1 |
+///     +----------------------+
+///     | DSL section header 2 |
+///     +======================+
+///     | Section data 0       | Data of each section, one after the other.
+///     +----------------------+
+///     | Section data 1       |
+///     +----------------------+
+///     | Section data 2       |
+///     +======================+
+///     | Symbol table         |
+///     +----------------------+
+///     | Symbol table names   |
+///     +======================+
+///
+/// DSL header: General information about the file.
+///
+///     +--------------------+-------------+--------------------------------+
+///     | Field              | Type        | Notes                          |
+///     +====================+=============+================================+
+///     | Magic              | uint32_t    | 0x304C5344 == 'DSL0'           |
+///     +--------------------+-------------+--------------------------------+
+///     | Version            | uint8_t     | Current version: 0             |
+///     +--------------------+-------------+--------------------------------+
+///     | Number of sections | uint8_t     |                                |
+///     +--------------------+-------------+--------------------------------+
+///     | Unused             | uint8_t[2]  | Unused, set to zero.           |
+///     +--------------------+-------------+--------------------------------+
+///     | Address space size | uint32_t    | From 0 to the max address.     |
+///     +====================+=============+================================+
+///
+/// DSL section header: Saved right after the DSL header. This is repeated for
+/// all sections stored in the file.
+///
+///     +====================+=============+================================+
+///     | Address            | uint16_t    | As seen by the DSP (in words). |
+///     +--------------------+-------------+--------------------------------+
+///     | Size (in bytes)    | uint16_t    |                                |
+///     +--------------------+-------------+--------------------------------+
+///     | Section type       | uint8_t     | See DSL_SEGMENT_*              |
+///     +--------------------+-------------+--------------------------------+
+///     | Unused             | uint8_t[3]  | Unused, set to zero.           |
+///     +--------------------+-------------+--------------------------------+
+///     | Data offset        | uint32_t    | Offset to the section data     |
+///     |                    |             | from the start of the file.    |
+///     +====================+=============+================================+
+///
+/// Section data: The data of the sections is stored right after the array of
+/// DSL section headers.
+
+/// DSL section header description
+typedef struct {
+    uint32_t address;       ///< Address to load the section to
+    uint32_t size;          ///< Size in bytes
+    uint32_t data_offset;   ///< Offset of the file to the data of the section
+    uint8_t type;           ///< DSL_SEGMENT_CODE or DSL_SEGMENT_DATA
+    uint8_t unused[3];      ///< Unused. Set to zero
+} dsl_section_header;
+
+static_assert(sizeof(dsl_section_header) == 16);
+
+#define DSL_SEGMENT_NOBITS      0
+#define DSL_SEGMENT_PROGBITS    1
+#define DSL_SEGMENT_RELOCATIONS 2
+
+/// DSL file header
+typedef struct {
+    uint32_t magic;             ///< Magic number: DSL_MAGIC
+    uint8_t version;            ///< Version number (currently 0)
+    uint8_t num_sections;       ///< Number of sections in the file
+    uint8_t unused[2];          ///< Unused. Set to zero
+    uint32_t addr_space_size;   ///< Size of the address space used by the DSL file
+    dsl_section_header section[]; ///< Array of section headers
+} dsl_header;
+
+/// Magic value of the DSL header file. Same as 'DSL0'
+#define DSL_MAGIC 0x304C5344
+
+static_assert(sizeof(dsl_header) == 12);
+
+/// DSL Symbol table: Saved right after the DSL section data.
+///
+///     +====================+=============+================================+
+///     | Number of symbols  | uint16_t    | Number of symbols.             |
+///     +--------------------+-------------+--------------------------------+
+///     | Unused             | uint8_t[2]  | Unused, set to zero.           |
+///     +====================+=============+================================+
+///
+/// Symbol data: Repeated once per symbol, stored right after the header.
+///
+///     +====================+=============+================================+
+///     | Name string offset | uint32_t    | Offset to name (from the       |
+///     |                    |             | symbol table header).          |
+///     +--------------------+-------------+--------------------------------+
+///     | Value              | uint32_t    | Address of the symbol.         |
+///     +--------------------+-------------+--------------------------------+
+///     | Attributes         | uint32_t    | Attributes (DSL_SYMBOL_*).     |
+///     +====================+=============+================================+
+///
+/// This is followed by a series of NUL-terminated strings (the symbol names).
+
+#define DSL_SYMBOL_PUBLIC       1 ///< If not set, the symbol is private
+#define DSL_SYMBOL_MAIN_BINARY  2 ///< If set, the symbol is in the main binary
+
+/// DSL symbol
+typedef struct {
+    uint32_t name_str_offset; ///< Offset to symbol name from symbol table base
+    uint32_t value;           ///< Address of the symbol
+    uint32_t attributes;      ///< Attributes of the symbol (DSL_SYMBOL_*).
+} dsl_symbol;
+
+static_assert(sizeof(dsl_symbol) == 12);
+
+/// DSL symbol table
+typedef struct {
+    uint16_t num_symbols; ///< Number of symbols in the file
+    uint8_t unused[2];    ///< Unused. Set to zero
+    dsl_symbol symbol[];  ///< Array of symbols
+} dsl_symbol_table;
+
+static_assert(sizeof(dsl_symbol_table) == 4);
+
+#endif // LIBNDS_DSL_H__

--- a/tools/dsltool/source/elf.c
+++ b/tools/dsltool/source/elf.c
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2025 Antonio Niño Díaz
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "elf.h"
+
+static void *file_load(const char *filename)
+{
+    FILE *f = fopen(filename, "rb");
+    if (f == NULL)
+    {
+        printf("%s couldn't be opened!", filename);
+        exit(EXIT_FAILURE);
+    }
+
+    fseek(f, 0, SEEK_END);
+    size_t size = ftell(f);
+    if (size == 0)
+    {
+        printf("Size of %s is 0!", filename);
+        fclose(f);
+        exit(EXIT_FAILURE);
+    }
+
+    rewind(f);
+    void *buffer = malloc(size);
+    if (buffer == NULL)
+    {
+        printf("Not enought memory to load %s!", filename);
+        fclose(f);
+        exit(EXIT_FAILURE);
+    }
+
+    if (fread(buffer, size, 1, f) != 1)
+    {
+        printf("Error while reading: %s", filename);
+        fclose(f);
+        free(buffer);
+        exit(EXIT_FAILURE);
+    }
+
+    fclose(f);
+
+    return buffer;
+}
+
+Elf32_Ehdr *elf_load(const char *path)
+{
+    // Load the whole ELF file
+    Elf32_Ehdr *header = file_load(path);
+
+    printf("File loaded: %s\n", path);
+
+    if (memcmp(&(header->e_ident[EI_MAG0]), ELF_MAGIC, 4))
+    {
+        printf("Invalid header magic\n");
+        goto cleanup;
+    }
+
+    if (header->e_ident[EI_CLASS] != ELFCLASS32)
+    {
+        printf("Not a 32-bit ELF file\n");
+        goto cleanup;
+    }
+
+    if (header->e_ident[EI_DATA] != ELFDATA2LSB)
+    {
+        printf("Not a little-endian ELF file\n");
+        goto cleanup;
+    }
+
+    if (header->e_ident[EI_VERSION] != EV_CURRENT)
+    {
+        printf("Invalid ELF version\n");
+        goto cleanup;
+    }
+
+    if (header->e_type != ET_EXEC)
+    {
+        printf("ELF file isn't executable\n");
+        goto cleanup;
+    }
+
+    if (header->e_machine != EM_ARM)
+    {
+        printf("ELF architecture isn't Teak\n");
+        goto cleanup;
+    }
+
+    if (header->e_ehsize != sizeof(Elf32_Ehdr))
+    {
+        printf("Invalid ELF header size\n");
+        goto cleanup;
+    }
+
+    if (header->e_phnum == 0)
+    {
+        printf("No program headers\n");
+        goto cleanup;
+    }
+
+    if (header->e_shnum == 0)
+    {
+        printf("No section headers\n");
+        goto cleanup;
+    }
+
+    printf("ELF header OK!\n");
+
+    printf("ELF entrypoint: 0x%04X\n", (unsigned int)header->e_entry);
+
+    printf("%u programs:\n", (unsigned int)header->e_phnum);
+
+    // Iterate over each program header
+    for (unsigned int i = 0; i < header->e_phnum; i++)
+    {
+        const Elf32_Phdr *phdr = elf_program(header, i);
+
+        if (phdr->p_vaddr != phdr->p_paddr)
+        {
+            printf("Physical and virtual addresses are different: 0x%X != 0x%X\n",
+                   (unsigned int)phdr->p_vaddr, (unsigned int)phdr->p_paddr);
+        }
+
+        if (phdr->p_filesz != phdr->p_memsz)
+        {
+            printf("File and memory sizes are different: 0x%X != 0x%X\n",
+                   (unsigned int)phdr->p_filesz, (unsigned int)phdr->p_memsz);
+        }
+
+        printf("%u: Address: 0x%04X | Size: 0x%04X | ",
+               i, (unsigned int)phdr->p_paddr, (unsigned int)phdr->p_memsz);
+
+        printf("%c", phdr->p_flags & PF_R ? 'R' : '-');
+        printf("%c", phdr->p_flags & PF_W ? 'W' : '-');
+        printf("%c", phdr->p_flags & PF_X ? 'X' : '-');
+
+        if (phdr->p_type == PT_NULL)
+            printf(" | NULL");
+        else if (phdr->p_type == PT_LOAD)
+            printf(" | LOAD");
+        else if (phdr->p_type == PT_DYNAMIC)
+            printf(" | DYNAMIC");
+        else if (phdr->p_type == PT_INTERP)
+            printf(" | INTERP");
+        else if (phdr->p_type == PT_NOTE)
+            printf(" | NOTE");
+        else if (phdr->p_type == PT_SHLIB)
+            printf(" | SHLIB");
+        else if (phdr->p_type == PT_PHDR)
+            printf(" | PHDR");
+        else
+            printf(" | %d", phdr->p_type);
+
+        printf("\n");
+
+        // Skip non-static sections.
+        //if (phdr->p_flags & 0x200000)
+        //    continue;
+    }
+
+    printf("%u sections:\n", (unsigned int)header->e_shnum);
+
+    // Iterate over each section header
+    for (unsigned int i = 0; i < header->e_shnum; i++)
+    {
+        const Elf32_Shdr *shdr = elf_section(header, i);
+
+        printf("%u: Address: 0x%08X | Size: 0x%04X | ",
+               i, (unsigned int)shdr->sh_addr, (unsigned int)shdr->sh_size);
+
+        printf("%c", shdr->sh_flags & SHF_WRITE ? 'W' : '-');
+        printf("%c", shdr->sh_flags & SHF_ALLOC ? 'A' : '-');
+        printf("%c", shdr->sh_flags & SHF_EXECINSTR ? 'X' : '-');
+
+        const char *name = elf_get_string_shstrtab(header, shdr->sh_name);
+        printf(" | %s : ", name == NULL ? "(empty)" : name);
+
+        if (shdr->sh_type == SHT_NULL)
+            printf("NULL");
+        else if (shdr->sh_type == SHT_PROGBITS)
+            printf("PROGBITS");
+        else if (shdr->sh_type == SHT_SYMTAB)
+            printf("SYMTAB");
+        else if (shdr->sh_type == SHT_STRTAB)
+            printf("STRTAB");
+        else if (shdr->sh_type == SHT_RELA)
+            printf("RELA");
+        else if (shdr->sh_type == SHT_HASH)
+            printf("HASH");
+        else if (shdr->sh_type == SHT_DYNAMIC)
+            printf("DYNAMIC");
+        else if (shdr->sh_type == SHT_NOTE)
+            printf("NOTE");
+        else if (shdr->sh_type == SHT_NOBITS)
+            printf("NOBITS");
+        else if (shdr->sh_type == SHT_REL)
+            printf("REL");
+        else if (shdr->sh_type == SHT_SHLIB)
+            printf("SHLIB");
+        else if (shdr->sh_type == SHT_DYNSYM)
+            printf("DYNSYM");
+        else if (shdr->sh_type == SHT_INIT_ARRAY)
+            printf("INIT_ARRAY");
+        else if (shdr->sh_type == SHT_FINI_ARRAY)
+            printf("FINI_ARRAY");
+        else if (shdr->sh_type == SHT_PREINIT_ARRAY)
+            printf("PREINIT_ARRAY");
+        else if (shdr->sh_type == SHT_GROUP)
+            printf("GROUP");
+        else if (shdr->sh_type == SHT_SYMTAB_SHNDX)
+            printf("SYMTAB_SHNDX");
+        else if (shdr->sh_type == SHT_ARM_ATTRIB)
+            printf("ARM_ATTRIB");
+        else
+            printf("%X", (unsigned int)shdr->sh_type);
+
+        printf("\n");
+    }
+
+    return header;
+
+cleanup:
+    free(header);
+    return NULL;
+}

--- a/tools/dsltool/source/elf.h
+++ b/tools/dsltool/source/elf.h
@@ -1,0 +1,329 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2025 Antonio Niño Díaz
+
+#ifndef ELF_H__
+#define ELF_H__
+
+#include <stdio.h>
+#include <stdint.h>
+
+// Types for use within ELF.
+typedef uint32_t Elf32_Addr;
+typedef uint16_t Elf32_Half;
+typedef uint8_t  Elf_Byte;
+typedef uint32_t Elf32_Off;
+typedef int32_t  Elf32_Sword;
+typedef uint32_t Elf32_Word;
+
+// Identification indices.
+typedef enum
+{
+    EI_MAG0    = 0, // File identification.
+    EI_MAG1    = 1, // File identification.
+    EI_MAG2    = 2, // File identification.
+    EI_MAG3    = 3, // File identification.
+    EI_CLASS   = 4, // File class.
+    EI_DATA    = 5, // Data encoding.
+    EI_VERSION = 6, // File version.
+    EI_PAD     = 7, // Start of padding bytes.
+    EI_NIDENT  = 16 // Size of e_ident[].
+} ELF_IDENT;
+
+// Header structure.
+typedef struct
+{
+    unsigned char e_ident[EI_NIDENT]; // Identification bytes.
+    Elf32_Half    e_type;             // Object file type.
+    Elf32_Half    e_machine;          // Object architecture.
+    Elf32_Word    e_version;          // Object file version.
+    Elf32_Addr    e_entry;            // Object entry point.
+    Elf32_Off     e_phoff;            // Program header file offset.
+    Elf32_Off     e_shoff;            // Section header file offset.
+    Elf32_Word    e_flags;            // Processor-specific flags.
+    Elf32_Half    e_ehsize;           // ELF header size.
+    Elf32_Half    e_phentsize;        // Program header entry size.
+    Elf32_Half    e_phnum;            // Program header entries.
+    Elf32_Half    e_shentsize;        // Section header entry size.
+    Elf32_Half    e_shnum;            // Section header entries.
+    Elf32_Half    e_shstrndx;         // String table index.
+} Elf32_Ehdr;
+
+// Program header structure.
+typedef struct
+{
+    Elf32_Word p_type;   // Segment type.
+    Elf32_Off  p_offset; // File offset.
+    Elf32_Addr p_vaddr;  // Virtual address.
+    Elf32_Addr p_paddr;  // Physical address.
+    Elf32_Word p_filesz; // File image size.
+    Elf32_Word p_memsz;  // Memory image size.
+    Elf32_Word p_flags;  // Segment flags.
+    Elf32_Word p_align;  // Alignment value.
+} Elf32_Phdr;
+
+// Object file type.
+typedef enum
+{
+    ET_NONE   = 0,  // No file type.
+    ET_REL    = 1,  // Relocatable file.
+    ET_EXEC   = 2,  // Executable file.
+    ET_DYN    = 3,  // Shared object file.
+    ET_CORE   = 4,  // Core file.
+} ELF_TYPE;
+
+// Object architecture.
+typedef enum
+{
+    EM_NONE  = 0,  // No machine.
+    EM_M32   = 1,  // AT&T WE 32100.
+    EM_SPARC = 2,  // SPARC.
+    EM_386   = 3,  // Intel 80386.
+    EM_68K   = 4,  // Motorola 68000.
+    EM_88K   = 5,  // Motorola 88000.
+    EM_860   = 7,  // Intel 80860.
+    EM_MIPS  = 8,  // MIPS RS3000.
+    EM_ARM   = 40, // ARM.
+} ELF_MACHINE;
+
+// Object file version.
+typedef enum
+{
+    EV_NONE    = 0, // Invalid version.
+    EV_CURRENT = 1  // Current version.
+} ELF_VERSION;
+
+// Magic number.
+#define ELF_MAGIC "\x7f" "ELF"
+
+// File class.
+typedef enum
+{
+    ELFCLASSNONE = 0, // Invalid class.
+    ELFCLASS32   = 1, // 32-bit objects.
+    ELFCLASS64   = 2, // 64-bit objects.
+} ELF_CLASS;
+
+// Data encoding.
+typedef enum
+{
+    ELFDATANONE = 0, // Invalid data encoding.
+    ELFDATA2LSB = 1, // Little endian.
+    ELFDATA2MSB = 2, // Big endian.
+} ELF_DATA;
+
+// Program header segment type.
+typedef enum
+{
+    PT_NULL    = 0, // Unused.
+    PT_LOAD    = 1, // Loadable segment.
+    PT_DYNAMIC = 2, // Dynamic linking information.
+    PT_INTERP  = 3, // Interpreter.
+    PT_NOTE    = 4, // Auxiliary information.
+    PT_SHLIB   = 5, // Reserved.
+    PT_PHDR    = 6  // Program header table.
+} ELF_P_TYPE;
+
+// Program header flag.
+typedef enum
+{
+    PF_R        = 4, // Read flag.
+    PF_W        = 2, // Write flag.
+    PF_X        = 1, // Execute flag.
+    PF_MASKPROC = 0xf0000000
+} ELF_P_FLAG;
+
+// Section header entry.
+typedef struct {
+    uint32_t   sh_name;
+    uint32_t   sh_type;
+    uint32_t   sh_flags;
+    Elf32_Addr sh_addr;
+    Elf32_Off  sh_offset;
+    uint32_t   sh_size;
+    uint32_t   sh_link;
+    uint32_t   sh_info;
+    uint32_t   sh_addralign;
+    uint32_t   sh_entsize;
+} Elf32_Shdr;
+
+typedef enum {
+    SHN_UNDEF     = 0,
+    SHN_LORESERVE = 0xff00,
+    SHN_LOPROC    = 0xff00,
+    SHN_BEFORE    = 0xff00,
+    SHN_AFTER     = 0xff01,
+    SHN_HIPROC    = 0xff1f,
+    SHN_LOOS      = 0xff20,
+    SHN_HIOS      = 0xff3f,
+    SHN_ABS       = 0xfff1,
+    SHN_COMMON    = 0xfff2,
+    SHN_XINDEX    = 0xffff,
+    SHN_HIRESERVE = 0xffff
+} ELF_SPECIAL_SECTION_INDICES;
+
+typedef enum {
+    SHT_NULL          = 0,
+    SHT_PROGBITS      = 1,
+    SHT_SYMTAB        = 2,
+    SHT_STRTAB        = 3,
+    SHT_RELA          = 4,
+    SHT_HASH          = 5,
+    SHT_DYNAMIC       = 6,
+    SHT_NOTE          = 7,
+    SHT_NOBITS        = 8,
+    SHT_REL           = 9,
+    SHT_SHLIB         = 10,
+    SHT_DYNSYM        = 11,
+    SHT_INIT_ARRAY    = 14,
+    SHT_FINI_ARRAY    = 15,
+    SHT_PREINIT_ARRAY = 16,
+    SHT_GROUP         = 17,
+    SHT_SYMTAB_SHNDX  = 18,
+    SHT_LOOS          = 0x60000000,
+    SHT_LOSUNW        = 0x6ffffff7,
+    SHT_HISUNW        = 0x6fffffff,
+    SHT_HIOS          = 0x6fffffff,
+    SHT_LOPROC        = 0x70000000,
+    SHT_SPARC_GOTDATA = 0x70000000,
+    SHT_ARM_ATTRIB    = 0x70000003,
+    SHT_HIPROC        = 0x7fffffff,
+    SHT_LOUSER        = 0x80000000,
+    SHT_HIUSER        = 0xffffffff
+} ELF_S_TYPE;
+
+typedef enum {
+    SHF_WRITE            = 0x1, // Writable during process execution.
+    SHF_ALLOC            = 0x2, // Occupies memory during process execution.
+    SHF_EXECINSTR        = 0x4, // Contains executable machine instructions.
+    SHF_MERGE            = 0x10,
+    SHF_STRINGS          = 0x20,
+    SHF_INFO_LINK        = 0x40,
+    SHF_LINK_ORDER       = 0x80,
+    SHF_OS_NONCONFORMING = 0x100,
+    SHF_GROUP            = 0x200,
+    SHF_TLS              = 0x400,
+    SHF_MASKOS           = 0x0ff00000,
+    SHF_ORDERED          = 0x40000000,
+    SHF_EXCLUDE          = 0x80000000,
+    SHF_MASKPROC         = 0xf0000000
+} ELF_S_FLAG;
+
+typedef struct {
+    Elf32_Addr r_offset; // Location (virtual address)
+    Elf32_Word r_info;   // (Symbol table index << 8) | (type of relocation)
+} Elf32_Rel;
+
+#define R_ARM_NONE          0
+#define R_ARM_ABS32         2
+#define R_ARM_REL32         3
+#define R_ARM_THM_CALL      10
+#define R_ARM_BASE_PREL     25
+#define R_ARM_GOT_BREL      26
+#define R_ARM_CALL          28
+
+typedef struct {
+    Elf32_Word  st_name;  // Symbol name (.strtab index)
+    Elf32_Word  st_value; // Value of symbol
+    Elf32_Word  st_size;  // Size of symbol
+    Elf_Byte    st_info;  // Type / binding attrs
+    Elf_Byte    st_other; // Visibility
+    Elf32_Half  st_shndx; // Section index of symbol
+} Elf32_Sym;
+
+// Symbol Table index of the undefined symbol
+#define ELF_SYM_UNDEFINED   0
+
+// Undefined index
+#define STN_UNDEF           0
+
+// st_info: Symbol Bindings
+#define STB_LOCAL       0   // Local symbol
+#define STB_GLOBAL      1   // Global symbol
+#define STB_WEAK        2   // Weakly defined global symbol
+#define STB_NUM         3
+
+#define STB_LOOS        10  // Operating system specific range
+#define STB_HIOS        12
+#define STB_LOPROC      13  // Processor-specific range
+#define STB_HIPROC      15
+
+// st_info: Symbol Types
+#define STT_NOTYPE      0   // Type not specified
+#define STT_OBJECT      1   // Associated with a data object
+#define STT_FUNC        2   // Associated with a function
+#define STT_SECTION     3   // Associated with a section
+#define STT_FILE        4   // Associated with a file name
+#define STT_COMMON      5   // Uninitialised common block
+#define STT_TLS         6   // Thread local data object
+#define STT_NUM         7
+
+// st_other: Visibility Types
+#define STV_DEFAULT     0   // Default binding type
+#define STV_INTERNAL    1   // Not referenced from outside
+#define STV_HIDDEN      2   // Not visible, may be used via ptr
+#define STV_PROTECTED   3   // Visible, not preemptible
+#define STV_EXPORTED    4
+#define STV_SINGLETON   5
+#define STV_ELIMINATE   6
+
+// st_info/st_other utility macros
+#define ELF_ST_BIND(info)           ((uint32_t)(info) >> 4)
+#define ELF_ST_TYPE(info)           ((uint32_t)(info) & 0xf)
+#define ELF_ST_INFO(bind, type)     ((Elf_Byte)(((bind) << 4) | ((type) & 0xf)))
+#define ELF_ST_VISIBILITY(other)    ((uint32_t)(other) & 3)
+
+static inline const Elf32_Phdr *elf_phdr(Elf32_Ehdr *hdr)
+{
+    return (Elf32_Phdr *)((uintptr_t)hdr + hdr->e_phoff);
+}
+
+static inline const Elf32_Phdr *elf_program(Elf32_Ehdr *hdr, int idx)
+{
+    return &elf_phdr(hdr)[idx];
+}
+
+static inline const void *elf_program_data(Elf32_Ehdr *hdr, int idx)
+{
+    return ((char *)hdr) + elf_phdr(hdr)[idx].p_offset;
+}
+
+static inline const Elf32_Shdr *elf_shdr(Elf32_Ehdr *hdr)
+{
+    return (Elf32_Shdr *)((uintptr_t)hdr + hdr->e_shoff);
+}
+
+static inline const Elf32_Shdr *elf_section(Elf32_Ehdr *hdr, int idx)
+{
+    return &elf_shdr(hdr)[idx];
+}
+
+static inline void *elf_section_data(Elf32_Ehdr *hdr, int idx)
+{
+    return ((char *)hdr) + elf_shdr(hdr)[idx].sh_offset;
+}
+
+static inline const char *elf_get_string_shstrtab(Elf32_Ehdr *hdr, int offset)
+{
+    if (hdr->e_shstrndx == SHN_UNDEF)
+        return NULL;
+
+    char *str_base = (char *)hdr + elf_section(hdr, hdr->e_shstrndx)->sh_offset;
+    if (str_base == NULL)
+        return NULL;
+
+    return str_base + offset;
+}
+
+static inline const char *elf_get_string_strtab(Elf32_Ehdr *hdr, int strtabndx, int offset)
+{
+    char *str_base = (char *)hdr + elf_section(hdr, strtabndx)->sh_offset;
+    if (str_base == NULL)
+        return NULL;
+
+    return str_base + offset;
+}
+
+Elf32_Ehdr *elf_load(const char *path);
+
+#endif // ELF_H__

--- a/tools/dsltool/source/main.c
+++ b/tools/dsltool/source/main.c
@@ -1,0 +1,518 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2025 Antonio Niño Díaz
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "elf.h"
+#include "dsl.h"
+#include "main_binary.h"
+#include "sym_table.h"
+
+// Useful commands to analyze ELF files:
+//
+// 1. readelf -a path/to/elf.elf
+//
+// 2. WONDERFUL_TOOLCHAIN=/opt/wonderful
+//    ARM_NONE_EABI_PATH=$(WONDERFUL_TOOLCHAIN)/toolchain/gcc-arm-none-eabi/bin/
+//    $(ARM_NONE_EABI_PATH)/arm-none-eabi-objdump -h -C -Ssr path/to/elf.elf
+
+void usage(void)
+{
+    printf("Usage: dsltool -i input.elf -o output.dsl [-m main_binary.elf]\n");
+}
+
+typedef struct {
+    uint32_t address;
+    uint32_t size;
+    uint32_t type;
+    void *data;
+} elf_section_info;
+
+#define MAX_SECTIONS 40
+
+int main(int argc, char *argv[])
+{
+    printf("dsltool " PACKAGE_VERSION "\n");
+    printf("=============\n");
+    printf("\n");
+
+    const char *in_file = NULL;
+    const char *out_file = NULL;
+    const char *main_binary_file = NULL;
+
+    for (int i = 1; i < argc; i++)
+    {
+        if (strcmp(argv[i], "-i") == 0)
+        {
+            i++;
+            if (i < argc)
+                in_file = argv[i];
+        }
+        else if (strcmp(argv[i], "-o") == 0)
+        {
+            i++;
+            if (i < argc)
+                out_file = argv[i];
+        }
+        else if (strcmp(argv[i], "-m") == 0)
+        {
+            i++;
+            if (i < argc)
+                main_binary_file = argv[i];
+        }
+        else if (strcmp(argv[i], "-h") == 0)
+        {
+            usage();
+            return 0;
+        }
+        else
+        {
+            printf("Unknown argument: %s\n", argv[i]);
+            usage();
+            return -1;
+        }
+    }
+
+    if (in_file == NULL)
+    {
+        printf("No input file provided\n");
+        usage();
+        return -1;
+    }
+
+    if (out_file == NULL)
+    {
+        printf("No output file provided\n");
+        usage();
+        return -1;
+    }
+
+    printf("\n");
+    printf("Loading main ELF\n");
+    printf("----------------\n");
+    printf("\n");
+
+    if (main_binary_file == NULL)
+    {
+        printf("No ELF provided. Skipping.\n");
+    }
+    else
+    {
+        // Load symbols and their addresses from the main ELF
+        main_binary_load(main_binary_file);
+    }
+
+    printf("\n");
+    printf("Loading ELF file\n");
+    printf("----------------\n");
+    printf("\n");
+
+    // Storage for all read sections
+    elf_section_info sections[MAX_SECTIONS];
+    int read_sections = 0;
+
+    Elf32_Ehdr *hdr = elf_load(in_file);
+    if (hdr == NULL)
+    {
+        printf("Failed to open: %s\n", in_file);
+        main_binary_free();
+        return -1;
+    }
+
+    printf("Looking for sections to include in DSL:\n");
+
+    uint32_t max_address = 0;
+
+    for (unsigned int i = 0; i < hdr->e_shnum; i++)
+    {
+        const Elf32_Shdr *shdr = elf_section(hdr, i);
+
+        // Exclude sections with no name
+        const char *name = elf_get_string_shstrtab(hdr, shdr->sh_name);
+        if (name == NULL)
+            continue;
+
+        // Exclude empty sections
+        size_t size = shdr->sh_size;
+        if (size == 0)
+            continue;
+
+        // Skip any region that isn't present after loading the ELF file
+        //if ((shdr->sh_flags & (SHF_WRITE | SHF_ALLOC | SHF_EXECINSTR)) == 0)
+        //    continue;
+
+        uintptr_t address = shdr->sh_addr;
+
+        int type = -1;
+
+        if (strcmp(name, ".nobits") == 0)
+            type = DSL_SEGMENT_NOBITS;
+        else if (strcmp(name, ".progbits") == 0)
+            type = DSL_SEGMENT_PROGBITS;
+        else if (strcmp(name, ".rel.progbits") == 0)
+            type = DSL_SEGMENT_RELOCATIONS;
+        else
+            continue;
+
+        void *data;
+
+        if (type == DSL_SEGMENT_PROGBITS)
+            data = elf_section_data(hdr, i);
+        else if (type == DSL_SEGMENT_RELOCATIONS)
+            data = elf_section_data(hdr, i);
+        else //if (type == DSL_SEGMENT_NOBITS)
+            data = NULL;
+
+        printf("Section %s: 0x%04zX (0x%zX bytes) | Type %d\n",
+               name, address, size, type);
+
+        sections[read_sections].address = address;
+        sections[read_sections].size = size;
+        sections[read_sections].type = type;
+        sections[read_sections].data = data;
+
+        uint32_t end_address = address + size;
+        if (end_address > max_address)
+            max_address = end_address;
+
+        read_sections++;
+    }
+
+    printf("Address space size: 0x%X\n", max_address);
+
+    printf("\n");
+    printf("Generating symbol table\n");
+    printf("-----------------------\n");
+    printf("\n");
+
+    int symtab_index = -1;
+    int strtab_index = -1;
+
+    for (unsigned int i = 0; i < hdr->e_shnum; i++)
+    {
+        const Elf32_Shdr *shdr = elf_section(hdr, i);
+
+        // Exclude sections with no name
+        const char *name = elf_get_string_shstrtab(hdr, shdr->sh_name);
+        if (name == NULL)
+            continue;
+
+        // Exclude empty sections
+        size_t size = shdr->sh_size;
+        if (size == 0)
+            continue;
+
+        if (strcmp(name, ".strtab") == 0)
+        {
+            printf(".strtab section: %d\n", i);
+            strtab_index = i;
+        }
+    }
+
+    for (unsigned int i = 0; i < hdr->e_shnum; i++)
+    {
+        const Elf32_Shdr *shdr = elf_section(hdr, i);
+
+        // Exclude sections with no name
+        const char *name = elf_get_string_shstrtab(hdr, shdr->sh_name);
+        if (name == NULL)
+            continue;
+
+        // Exclude empty sections
+        size_t size = shdr->sh_size;
+        if (size == 0)
+            continue;
+
+        if (strcmp(name, ".symtab") != 0)
+            continue;
+
+        printf(".symtab section: %d\n", i);
+
+        symtab_index = i;
+
+        const Elf32_Sym *sym = elf_section_data(hdr, symtab_index);
+        size_t sym_num = size / sizeof(Elf32_Sym);
+
+        printf("Total number of symbols: %zu\n", sym_num);
+
+        for (size_t s = 0; s < sym_num; s++, sym++)
+        {
+            uint8_t bind = ELF_ST_BIND(sym->st_info);
+            uint8_t type = ELF_ST_TYPE(sym->st_info);
+            uint8_t vis = ELF_ST_VISIBILITY(sym->st_other);
+
+            const char *name;
+
+            if (type == STT_SECTION)
+            {
+                const Elf32_Shdr *shdr = elf_section(hdr, sym->st_shndx);
+                name = elf_get_string_shstrtab(hdr, shdr->sh_name);
+            }
+            else
+            {
+                name = elf_get_string_strtab(hdr, strtab_index, sym->st_name);
+            }
+
+            bool public = true;
+
+            // Only save addresses of functions and objects
+            if ((type != STT_FUNC) && (type != STT_OBJECT))
+                public = false;
+
+            // Only if they are global (not local)
+            if (bind != STB_GLOBAL)
+                public = false;
+
+            // Only if they are visible from outside of the ELF
+            if ((vis != STV_DEFAULT) && (vis != STV_EXPORTED))
+                public = false;
+
+            bool unknown = (type == STT_NOTYPE);
+
+            printf("%zu: \"%s\" = %u%s%s\n", s, name, sym->st_value,
+                   public ? " [Public]" : "", unknown ? " [Unknown]": "");
+
+            sym_add_to_table(name, sym->st_value, public, unknown);
+        }
+    }
+
+    printf("\n");
+    printf("Generating DSL file\n");
+    printf("-------------------\n");
+    printf("\n");
+
+    printf("Opening: %s\n", out_file);
+
+    FILE *f_dsl = fopen(out_file, "wb");
+    if (f_dsl == NULL)
+    {
+        printf("Failed to open output file: %s\n", out_file);
+        free(hdr);
+        main_binary_free();
+        return -1;
+    }
+
+    // Write header
+
+    dsl_header header = {
+        .magic = DSL_MAGIC,
+        .version = 0,
+        .num_sections = read_sections,
+        .unused = {0},
+        .addr_space_size = max_address,
+    };
+
+    if (fwrite(&header, sizeof(dsl_header), 1, f_dsl) != 1)
+    {
+        printf("Failed to write DSL header\n");
+        free(hdr);
+        main_binary_free();
+        fclose(f_dsl);
+        remove(out_file);
+        return -1;
+    }
+
+    // Check relocations to see that there are unsupported types
+
+    int progbits_index = -1;
+
+    for (int i = 0; i < read_sections; i++)
+    {
+        if (sections[i].type == DSL_SEGMENT_PROGBITS)
+        {
+            progbits_index = i;
+            break;
+        }
+    }
+
+    if (progbits_index == -1)
+    {
+        printf("Can't find progbits section to apply relocations\n");
+        free(hdr);
+        main_binary_free();
+        fclose(f_dsl);
+        remove(out_file);
+        return -1;
+    }
+
+    for (int i = 0; i < read_sections; i++)
+    {
+        if (sections[i].type != DSL_SEGMENT_RELOCATIONS)
+            continue;
+
+        printf("Checking relocations\n");
+
+        Elf32_Rel *rel = sections[i].data;
+        size_t num_rel = sections[i].size / sizeof(Elf32_Rel);
+
+        // First, check that we only have valid relocations and mark all the
+        // symbols that are referenced by relocations
+        for (size_t r = 0; r < num_rel; r++)
+        {
+            uint8_t type = rel[r].r_info & 0xFF;
+            uint8_t symbol_index = rel[r].r_info >> 8;
+
+            if ((type != R_ARM_ABS32) && (type != R_ARM_THM_CALL) &&
+                (type != R_ARM_CALL))
+            {
+                printf("Invalid relocation. Index %zu. Type %u\n", r, type);
+                free(hdr);
+                main_binary_free();
+                fclose(f_dsl);
+                remove(out_file);
+                return -1;
+            }
+
+            sym_set_as_used(symbol_index);
+        }
+
+        // Remove unused symbols and sort them by name
+
+        sym_clear_unused();
+
+        printf("Sorting symbol table...\n");
+
+        sym_sort_table();
+
+        sym_print_table();
+
+        // Now save each relocation replacing the symbol index by the new
+        // index in the reduced table.
+
+        for (size_t r = 0; r < num_rel; r++)
+        {
+            uint32_t offset = rel[r].r_offset;
+            uint8_t type = rel[r].r_info & 0xFF;
+            uint8_t old_symbol_index = rel[r].r_info >> 8;
+
+            int new_index = sym_get_sym_index_by_old_index(old_symbol_index);
+            if (new_index == -1)
+            {
+                printf("Failed to translate index for relocation %zu\n", r);
+                free(hdr);
+                main_binary_free();
+                fclose(f_dsl);
+                remove(out_file);
+                return -1;
+            }
+
+            rel[r].r_offset = offset;
+            rel[r].r_info  = type | (new_index << 8);
+        }
+    }
+
+    // Write section headers
+
+    printf("Writing %d sections\n", read_sections);
+
+    unsigned int full_header_size =
+        sizeof(dsl_header) + sizeof(dsl_section_header) * read_sections;
+
+    unsigned int current_section_offset = full_header_size;
+
+    for (int i = 0; i < read_sections; i++)
+    {
+        uint32_t offset = (sections[i].type == DSL_SEGMENT_NOBITS) ?
+                          0 : current_section_offset;
+
+        dsl_section_header section_header = {
+            .address = sections[i].address,
+            .size = sections[i].size,
+            .data_offset = offset,
+            .type = sections[i].type,
+            .unused = {0},
+        };
+
+        if (sections[i].type != DSL_SEGMENT_NOBITS)
+        {
+            printf("Section %d: offset 0x%X, 0x%X bytes\n",
+                   i, offset, sections[i].size);
+
+            current_section_offset += sections[i].size;
+        }
+        else
+        {
+            printf("Section %d: nobits, 0x%X bytes\n", i, sections[i].size);
+        }
+
+        if (fwrite(&section_header, sizeof(dsl_section_header), 1, f_dsl) != 1)
+        {
+            printf("Failed to write DSL header for section %d\n", i);
+            free(hdr);
+            main_binary_free();
+            fclose(f_dsl);
+            remove(out_file);
+            return -1;
+        }
+    }
+
+    // Write section data
+
+    for (int i = 0; i < read_sections; i++)
+    {
+        if (sections[i].type == DSL_SEGMENT_NOBITS)
+        {
+            // Nothing to write to the file
+        }
+        else if (sections[i].type == DSL_SEGMENT_PROGBITS)
+        {
+            printf("Writing data of section %d (progbits)\n", i);
+
+            if (fwrite(sections[i].data, sections[i].size, 1, f_dsl) != 1)
+            {
+                printf("Failed to write DSL data for section %d\n", i);
+                free(hdr);
+                main_binary_free();
+                fclose(f_dsl);
+                remove(out_file);
+                return -1;
+            }
+        }
+        else if (sections[i].type == DSL_SEGMENT_RELOCATIONS)
+        {
+            printf("Writing data of section %d (relocations)\n", i);
+
+            if (fwrite(sections[i].data, sections[i].size, 1, f_dsl) != 1)
+            {
+                printf("Failed to write DSL data for section %d\n", i);
+                free(hdr);
+                main_binary_free();
+                fclose(f_dsl);
+                remove(out_file);
+                return -1;
+            }
+        }
+    }
+
+    // Save symbol table to file
+
+    printf("Saving symbol table...\n");
+
+    if (sym_table_save_to_file(f_dsl) != 0)
+    {
+        printf("Failed to save symbol table!\n");
+        free(hdr);
+        main_binary_free();
+        fclose(f_dsl);
+        remove(out_file);
+        return -1;
+    }
+
+    sym_clear_table();
+
+    fclose(f_dsl);
+
+    printf("\n");
+    printf("Freeing ELF files\n");
+    printf("-----------------\n");
+    printf("\n");
+
+    free(hdr);
+    main_binary_free();
+
+    return 0;
+}

--- a/tools/dsltool/source/main_binary.c
+++ b/tools/dsltool/source/main_binary.c
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2025 Antonio Niño Díaz
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "elf.h"
+
+static Elf32_Ehdr *hdr = NULL;
+
+static int symtab_index = -1;
+static size_t symtab_size = 0;
+
+static int strtab_index = -1;
+
+int main_binary_load(const char *path)
+{
+    hdr = elf_load(path);
+    if (hdr == NULL)
+    {
+        printf("Failed to open: %s\n", path);
+        return -1;
+    }
+
+    for (unsigned int i = 0; i < hdr->e_shnum; i++)
+    {
+        const Elf32_Shdr *shdr = elf_section(hdr, i);
+
+        // Exclude sections with no name
+        const char *name = elf_get_string_shstrtab(hdr, shdr->sh_name);
+        if (name == NULL)
+            continue;
+
+        // Exclude empty sections
+        size_t size = shdr->sh_size;
+        if (size == 0)
+            continue;
+
+        if (strcmp(name, ".strtab") == 0)
+        {
+            strtab_index = i;
+        }
+        else if (strcmp(name, ".symtab") == 0)
+        {
+            symtab_index = i;
+            symtab_size = size;
+        }
+    }
+
+    if ((symtab_index == -1) || (strtab_index == -1))
+    {
+        printf("Can't find strab or symtab\n");
+        free(hdr);
+        return -1;
+    }
+
+    printf("Found %zu symbols\n", symtab_size / sizeof(Elf32_Sym));
+
+    return 0;
+}
+
+bool main_binary_is_loaded(void)
+{
+    return hdr != NULL;
+}
+
+uint32_t main_binary_get_symbol_value(const char *name)
+{
+    if (hdr == NULL)
+        return UINT32_MAX;
+
+    const Elf32_Sym *sym = elf_section_data(hdr, symtab_index);
+    size_t sym_num = symtab_size / sizeof(Elf32_Sym);
+
+    for (size_t s = 0; s < sym_num; s++, sym++)
+    {
+        uint8_t type = ELF_ST_TYPE(sym->st_info);
+
+        const char *sym_name;
+
+        // Only save addresses of functions and objects, not sections
+        if ((type != STT_FUNC) && (type != STT_OBJECT))
+            continue;
+
+        sym_name = elf_get_string_strtab(hdr, strtab_index, sym->st_name);
+
+        if (strcmp(sym_name, name) != 0)
+            continue;
+
+        return sym->st_value;
+    }
+
+    return UINT32_MAX;
+}
+
+void main_binary_free(void)
+{
+    free(hdr);
+}

--- a/tools/dsltool/source/main_binary.h
+++ b/tools/dsltool/source/main_binary.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2025 Antonio Niño Díaz
+
+#ifndef MAIN_BINARY_H__
+#define MAIN_BINARY_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+
+int main_binary_load(const char *path);
+bool main_binary_is_loaded(void);
+uint32_t main_binary_get_symbol_value(const char *name);
+void main_binary_free(void);
+
+#endif // MAIN_BINARY_H__

--- a/tools/dsltool/source/sym_table.c
+++ b/tools/dsltool/source/sym_table.c
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2025 Antonio Niño Díaz
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "dsl.h"
+#include "main_binary.h"
+
+typedef struct {
+    const char *name;
+    uint32_t value;
+    unsigned int initial_index;
+    bool public;
+    bool used;
+    bool unknown;
+} elf_symbol_info;
+
+elf_symbol_info *elf_symbols;
+size_t elf_symbols_num = 0;
+
+void sym_add_to_table(const char *name, uint32_t value, bool is_public, bool is_unknown)
+{
+    size_t new_size = sizeof(elf_symbol_info) * (elf_symbols_num + 1);
+    elf_symbols = realloc(elf_symbols, new_size);
+
+    elf_symbols[elf_symbols_num].name = name;
+    elf_symbols[elf_symbols_num].value = value;
+    elf_symbols[elf_symbols_num].used = is_public;
+    elf_symbols[elf_symbols_num].public = is_public;
+    elf_symbols[elf_symbols_num].unknown = is_unknown;
+    elf_symbols[elf_symbols_num].initial_index = elf_symbols_num;
+
+    elf_symbols_num++;
+}
+
+int sym_set_as_used(unsigned int index)
+{
+    if (index >= elf_symbols_num)
+        return -1;
+
+    elf_symbols[index].used = true;
+    return 0;
+}
+
+bool sym_is_unknown(unsigned int index)
+{
+    if (index >= elf_symbols_num)
+        return false;
+
+    return elf_symbols[index].unknown;
+}
+
+const char *sym_get_name(unsigned int index)
+{
+    if (index >= elf_symbols_num)
+        return false;
+
+    return elf_symbols[index].name;
+}
+
+int sym_get_sym_index_by_old_index(unsigned int index)
+{
+    elf_symbol_info *sym = elf_symbols;
+
+    for (size_t i = 0; i < elf_symbols_num; i++, sym++)
+    {
+        if (sym->initial_index == index)
+            return i;
+    }
+
+    return -1;
+}
+
+static int sym_compare_entries(const void *p1, const void *p2)
+{
+    const char *name1 = ((elf_symbol_info *)p1)->name;
+    const char *name2 = ((elf_symbol_info *)p2)->name;
+
+    return strcmp(name1, name2);
+}
+
+void sym_clear_unused(void)
+{
+    size_t i = 0;
+    while (1)
+    {
+        if (i >= elf_symbols_num)
+            break;
+
+        if (elf_symbols[i].used)
+        {
+            i++;
+            continue;
+        }
+
+        for (size_t j = i; j < elf_symbols_num - 1; j++)
+            elf_symbols[j] = elf_symbols[j + 1];
+
+        elf_symbols_num--;
+    }
+}
+
+void sym_sort_table(void)
+{
+    qsort(elf_symbols, elf_symbols_num, sizeof(elf_symbol_info), sym_compare_entries);
+}
+
+void sym_clear_table(void)
+{
+    free(elf_symbols);
+    elf_symbols = NULL;
+    elf_symbols_num = 0;
+}
+
+void sym_print_table(void)
+{
+    elf_symbol_info *sym = elf_symbols;
+
+    printf("Symbol table (%zu entries)\n", elf_symbols_num);
+
+    for (size_t i = 0; i < elf_symbols_num; i++, sym++)
+    {
+        printf("%zu: \"%s\" = %u%s%s\n", i, sym->name, sym->value,
+               sym->public ? " [Public]" : "",
+               sym->unknown ? " [Unknown]" : "");
+    }
+}
+
+int sym_table_save_to_file(FILE *f)
+{
+    dsl_symbol_table header = {
+        .num_symbols = elf_symbols_num,
+        .unused = {0},
+    };
+
+    if (fwrite(&header, sizeof(dsl_symbol_table), 1, f) != 1)
+    {
+        printf("Failed to write DSL header\n");
+        return -1;
+    }
+
+    // We're going to start writing strings right after the symbol array.
+    uint32_t offset = sizeof(dsl_symbol_table)
+                    + sizeof(dsl_symbol) * elf_symbols_num;
+
+    for (size_t i = 0; i < elf_symbols_num; i++)
+    {
+        dsl_symbol sym = {
+            .name_str_offset = offset,
+            .value = elf_symbols[i].value,
+            .attributes = 0,
+        };
+
+        if (elf_symbols[i].public)
+            sym.attributes |= DSL_SYMBOL_PUBLIC;
+
+        // Check if this symbol is unknown. If so, look for it in the main
+        // binary and edit the symbol to define the address.
+        if (elf_symbols[i].unknown)
+        {
+            const char *sym_name = sym_get_name(i);
+            printf("Unknown symbol [%s]\n", sym_name);
+
+            // Look for the symbol in the main binary
+            if (!main_binary_is_loaded())
+            {
+                printf("No main binary provided. Can't resolve address.\n");
+                return -1;
+            }
+
+            printf("Searching main binary...\n");
+
+            uint32_t sym_addr = main_binary_get_symbol_value(sym_name);
+            if (sym_addr == UINT32_MAX)
+            {
+                printf("Symbol not found.\n");
+                return -1;
+            }
+
+            printf("Symbol found: 0x%08X\n", sym_addr);
+
+            sym.value = sym_addr;
+            sym.attributes |= DSL_SYMBOL_MAIN_BINARY;
+        }
+
+        // Allocate space for this name
+        offset += strlen(elf_symbols[i].name) + 1;
+
+        if (fwrite(&sym, sizeof(dsl_symbol), 1, f) != 1)
+        {
+            printf("Failed to write symbol %zu\n", i);
+            return -1;
+        }
+    }
+
+    for (size_t i = 0; i < elf_symbols_num; i++)
+    {
+        const char *name = elf_symbols[i].name;
+        size_t len = strlen(name) + 1; // Include NUL terminator
+
+        if (fwrite(name, 1, len, f) != len)
+        {
+            printf("Failed to write symbol name %zu\n", i);
+            return -1;
+        }
+    }
+
+    return 0;
+}

--- a/tools/dsltool/source/sym_table.h
+++ b/tools/dsltool/source/sym_table.h
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Zlib
+//
+// Copyright (C) 2025 Antonio Niño Díaz
+
+#ifndef SYM_TABLE_H__
+#define SYM_TABLE_H__
+
+#include <stdint.h>
+#include <stdio.h>
+
+void sym_add_to_table(const char *name, uint32_t value, bool is_public, bool is_unknown);
+int sym_set_as_used(unsigned int index);
+
+bool sym_is_unknown(unsigned int index);
+const char *sym_get_name(unsigned int index);
+int sym_get_sym_index_by_old_index(unsigned int index);
+
+void sym_clear_unused(void);
+void sym_sort_table(void);
+void sym_clear_table(void);
+void sym_print_table(void);
+int sym_table_save_to_file(FILE *f);
+
+#endif // SYM_TABLE_H__


### PR DESCRIPTION
This PR introduces `dlstool`, a tool that converts `.elf` files into dynamic libraries in `.dsl` to be loaded by libnds.

It also adds an example of how to use it.

More context and discussion here:

https://github.com/blocksds/sdk/issues/44