### PR TITLE
sys/crts: fix global initializers on picolibc 1.8.10

### DIFF
--- a/sys/crts/dldi.ld
+++ b/sys/crts/dldi.ld
@@ -75,11 +75,13 @@ SECTIONS
 
     . = ALIGN(32 / 8);
     PROVIDE (__preinit_array_start = .);
+    PROVIDE (__bothinit_array_start = .);
     .preinit_array     : { KEEP (*(.preinit_array)) } >ddmem = 0xff
     PROVIDE (__preinit_array_end = .);
     PROVIDE (__init_array_start = .);
     .init_array     : { KEEP (*(.init_array)) } >ddmem = 0xff
     PROVIDE (__init_array_end = .);
+    PROVIDE (__bothinit_array_end = .);
     PROVIDE (__fini_array_start = .);
     .fini_array     : { KEEP (*(.fini_array)) } >ddmem = 0xff
     PROVIDE (__fini_array_end = .);

--- a/sys/crts/ds_arm7.ld
+++ b/sys/crts/ds_arm7.ld
@@ -151,18 +151,18 @@ SECTIONS
        the linker would then create the section even if it turns out to
        be empty, which isn't pretty.  */
     . = ALIGN(32 / 8);
-    .preinit_array :
-    {
-        PROVIDE (__preinit_array_start = .);
-        KEEP (*(.preinit_array))
-        PROVIDE (__preinit_array_end = .);
-    } >iwram AT>ewram
     .init_array :
     {
+        PROVIDE (__preinit_array_start = .);
+        PROVIDE (__bothinit_array_start = .);
+        KEEP (*(.preinit_array))
+        PROVIDE (__preinit_array_end = .);
+
         PROVIDE (__init_array_start = .);
         KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
         KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
         PROVIDE (__init_array_end = .);
+        PROVIDE (__bothinit_array_end = .);
     } >iwram AT>ewram
     .fini_array :
     {

--- a/sys/crts/ds_arm7_iwram.ld
+++ b/sys/crts/ds_arm7_iwram.ld
@@ -98,18 +98,18 @@ SECTIONS
        the linker would then create the section even if it turns out to
        be empty, which isn't pretty.  */
     . = ALIGN(32 / 8);
-    .preinit_array :
-    {
-        PROVIDE (__preinit_array_start = .);
-        KEEP (*(.preinit_array))
-        PROVIDE (__preinit_array_end = .);
-    } >iwram = 0xff
     .init_array :
     {
+        PROVIDE (__preinit_array_start = .);
+        PROVIDE (__bothinit_array_start = .);
+        KEEP (*(.preinit_array))
+        PROVIDE (__preinit_array_end = .);
+
         PROVIDE (__init_array_start = .);
         KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
         KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
         PROVIDE (__init_array_end = .);
+        PROVIDE (__bothinit_array_end = .);
     } >iwram = 0xff
     .fini_array :
     {

--- a/sys/crts/ds_arm7_vram.ld
+++ b/sys/crts/ds_arm7_vram.ld
@@ -101,18 +101,18 @@ SECTIONS
        the linker would then create the section even if it turns out to
        be empty, which isn't pretty.  */
     . = ALIGN(32 / 8);
-    .preinit_array :
-    {
-        PROVIDE (__preinit_array_start = .);
-        KEEP (*(.preinit_array))
-        PROVIDE (__preinit_array_end = .);
-    } >vram = 0xff
     .init_array :
     {
+        PROVIDE (__preinit_array_start = .);
+        PROVIDE (__bothinit_array_start = .);
+        KEEP (*(.preinit_array))
+        PROVIDE (__preinit_array_end = .);
+
         PROVIDE (__init_array_start = .);
         KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
         KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
         PROVIDE (__init_array_end = .);
+        PROVIDE (__bothinit_array_end = .);
     } >vram = 0xff
     .fini_array :
     {

--- a/sys/crts/ds_arm9.ld
+++ b/sys/crts/ds_arm9.ld
@@ -135,18 +135,18 @@ SECTIONS
        the linker would then create the section even if it turns out to
        be empty, which isn't pretty.  */
     . = ALIGN(32 / 8);
-    .preinit_array :
-    {
-        PROVIDE (__preinit_array_start = .);
-        KEEP (*(.preinit_array))
-        PROVIDE (__preinit_array_end = .);
-    } >ewram :main = 0xff
     .init_array :
     {
+        PROVIDE (__preinit_array_start = .);
+        PROVIDE (__bothinit_array_start = .);
+        KEEP (*(.preinit_array))
+        PROVIDE (__preinit_array_end = .);
+
         PROVIDE (__init_array_start = .);
         KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
         KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
         PROVIDE (__init_array_end = .);
+        PROVIDE (__bothinit_array_end = .);
     } >ewram :main = 0xff
     .fini_array :
     {


### PR DESCRIPTION
An optimization was implemented that I missed while checking regressions, and the newly required symbols were not caught by the linker either. Oops.