### PR TITLE
dsltool: Allow loading ELF files with more than 256 symbols

### DIFF
--- a/tools/dsltool/source/main.c
+++ b/tools/dsltool/source/main.c
@@ -359,7 +359,7 @@ int main(int argc, char *argv[])
         for (size_t r = 0; r < num_rel; r++)
         {
             uint8_t type = rel[r].r_info & 0xFF;
-            uint8_t symbol_index = rel[r].r_info >> 8;
+            int symbol_index = rel[r].r_info >> 8;
 
             if ((type != R_ARM_ABS32) && (type != R_ARM_THM_CALL) &&
                 (type != R_ARM_CALL))
@@ -390,7 +390,7 @@ int main(int argc, char *argv[])
         {
             uint32_t offset = rel[r].r_offset;
             uint8_t type = rel[r].r_info & 0xFF;
-            uint8_t old_symbol_index = rel[r].r_info >> 8;
+            int old_symbol_index = rel[r].r_info >> 8;
 
             int new_index = sym_get_sym_index_by_old_index(old_symbol_index);
             if (new_index == -1)


### PR DESCRIPTION
There is currently an inconsistency in how elf symbol indices are handled by dsltool -- in `sym_table.c` they are treated as 32-bit integers while in `main.c` they are single bytes. In `main.c` this leads to integer overflow when larger (or really even moderately-sized) symtables are processed.

This fix just changes them to signed 32-bit integers to match the declaration of `new_index` in `main.c`.