### PR TITLE
build: real files for arm7, amr9 & teak ELF

### DIFF
--- a/sys/default_makefiles/rom_arm9arm7/Makefile
+++ b/sys/default_makefiles/rom_arm9arm7/Makefile
@@ -52,7 +52,7 @@ ROM		:= $(NAME).nds
 # Targets
 # -------
 
-.PHONY: all clean arm9 arm7 dldipatch sdimage
+.PHONY: all clean dldipatch sdimage
 
 all: $(ROM)
 
@@ -62,10 +62,10 @@ clean:
 	$(V)$(MAKE) -f Makefile.arm7 clean --no-print-directory
 	$(V)$(RM) $(ROM) build $(SDIMAGE)
 
-arm9:
+build/arm9.elf:
 	$(V)$(MAKE) -f Makefile.arm9 --no-print-directory
 
-arm7:
+build/arm7.elf:
 	$(V)$(MAKE) -f Makefile.arm7 --no-print-directory
 
 ifneq ($(strip $(NITROFSDIR)),)
@@ -83,7 +83,7 @@ else
     GAME_FULL_TITLE := $(GAME_TITLE);$(GAME_SUBTITLE);$(GAME_AUTHOR)
 endif
 
-$(ROM): arm9 arm7
+$(ROM): build/arm9.elf build/arm7.elf
 	@echo "  NDSTOOL $@"
 	$(V)$(BLOCKSDS)/tools/ndstool/ndstool -c $@ \
 		-7 build/arm7.elf -9 build/arm9.elf \

--- a/sys/default_makefiles/rom_arm9arm7teak/Makefile
+++ b/sys/default_makefiles/rom_arm9arm7teak/Makefile
@@ -53,7 +53,7 @@ ROM		:= $(NAME).nds
 # Targets
 # -------
 
-.PHONY: all clean arm9 arm7 dldipatch sdimage teak
+.PHONY: all clean dldipatch sdimage
 
 all: $(ROM)
 
@@ -65,14 +65,14 @@ clean:
 	$(V)$(RM) $(ROM) build $(SDIMAGE)
 	$(V)$(RM) arm9/data/teak_tlf.bin
 
-arm9: teak
+build/arm9.elf: build/teak.tlf
 	$(V)$(CP) build/teak.tlf arm9/data/teak_tlf.bin
 	$(V)$(MAKE) -f Makefile.arm9 --no-print-directory
 
-arm7:
+build/arm7.elf:
 	$(V)$(MAKE) -f Makefile.arm7 --no-print-directory
 
-teak:
+build/teak.tlf:
 	$(V)$(MAKE) -f Makefile.teak --no-print-directory
 
 ifneq ($(strip $(NITROFSDIR)),)
@@ -90,7 +90,7 @@ else
     GAME_FULL_TITLE := $(GAME_TITLE);$(GAME_SUBTITLE);$(GAME_AUTHOR)
 endif
 
-$(ROM): arm9 arm7
+$(ROM): build/arm7.elf build/arm9.elf
 	@echo "  NDSTOOL $@"
 	$(V)$(BLOCKSDS)/tools/ndstool/ndstool -c $@ \
 		-7 build/arm7.elf -9 build/arm9.elf \

--- a/sys/default_makefiles/rom_arm9teak/Makefile
+++ b/sys/default_makefiles/rom_arm9teak/Makefile
@@ -58,7 +58,7 @@ ROM		:= $(NAME).nds
 # Targets
 # -------
 
-.PHONY: all clean arm9 dldipatch sdimage teak
+.PHONY: all clean dldipatch sdimage
 
 all: $(ROM)
 
@@ -69,11 +69,11 @@ clean:
 	$(V)$(RM) $(ROM) build $(SDIMAGE)
 	$(V)$(RM) arm9/data/teak_tlf.bin
 
-arm9: teak
+build/arm9.elf: build/teak.tlf
 	$(V)$(CP) build/teak.tlf arm9/data/teak_tlf.bin
 	$(V)$(MAKE) -f Makefile.arm9 --no-print-directory
 
-teak:
+build/teak.tlf:
 	$(V)$(MAKE) -f Makefile.teak --no-print-directory
 
 ifneq ($(strip $(NITROFSDIR)),)
@@ -91,7 +91,7 @@ else
     GAME_FULL_TITLE := $(GAME_TITLE);$(GAME_SUBTITLE);$(GAME_AUTHOR)
 endif
 
-$(ROM): arm9
+$(ROM): build/arm9.elf
 	@echo "  NDSTOOL $@"
 	$(V)$(BLOCKSDS)/tools/ndstool/ndstool -c $@ \
 		-7 $(ARM7ELF) -9 build/arm9.elf \


### PR DESCRIPTION
This enables to avoid making them when they
exists.  Otherwise we rely on a .PHONY rule
which works, but is suboptimal.