### PR TITLE
arm7 crt0: use new libnds function to generate an argv struct from the device list if nothing was provided

### DIFF
--- a/sys/crts/ds_arm7_crt0.s
+++ b/sys/crts/ds_arm7_crt0.s
@@ -105,6 +105,10 @@ NotTWL:
     ldr     r3, =__libc_init_array  // global constructors
     bl      _blx_r3_stub
 
+    // Checks if the argv struct has been passed to the application, and if not, constructs one from the device list (if any)
+    ldr     r3, =check_device_list
+    bl      _blx_r3_stub
+
     // Prepare address, arguments and return address of main().
     mov     r0, #0              // int argc
     mov     r1, #0              // char *argv[]


### PR DESCRIPTION
Requires https://github.com/blocksds/libnds/pull/187, the function is called before signaling the arm9 to proceed with the startup sequence, so there are no possible race conditions