### PR TITLE
crt0: Flush data cache after all the bss and arm9i binary are set up

### DIFF
--- a/sys/crts/ds_arm9_crt0.s
+++ b/sys/crts/ds_arm9_crt0.s
@@ -130,6 +130,18 @@ _start:
     bl      ClearMem
 
 NotTWL:
+    // Flush caches
+
+    // The instructions above, write data to ram areas that are backed up by a cache
+    // flush all the written data to RAM.
+    // This is needed especially for the arm9i binary on a DSi, since it could contain
+    // data sections that could be not available right at the start of the program since
+    // they're still in cache
+    ldr     r3, =CP15_CleanAndFlushDCache
+    blx     r3
+
+    ldr     r3, =CP15_FlushICache
+    blx     r3
 
     // Setup heap limits
 


### PR DESCRIPTION
Currently, the arm9 crt0 is loading the arm9i binary (and clearing bss regions), **after** the mpu has been set up and the data/instruction caches have been flushed.
This causes a race condition happening when accessing data from the twl code region right at the program start, before the cpu has flushed it to ram.
This minimal reproduction example shows the problem:
main.c
```c
#include <nds.h>

char sec_buff[512];
void aaa();
TWL_CODE __attribute__((noinline)) void a()
{
	aaa(sec_buff, 1 * 512);
	asm volatile("udf #0" ::: "memory");
	volatile bool a = true;
	while(a);
	return;
}

int main(int argc, char **argv)
{
	REG_IE = 0;
	// DC_FlushAll();
    a();
    return 0;
}
```
aaa.c
```c
#include <nds.h>

ITCM_CODE ARM_CODE __attribute__((noinline))
void aaa()
{
	
}
```
GCC generates this code when compiling those 2 source files
```

02007ebc <a>:
 2007ebc:	2180      	movs	r1, #128	@ 0x80
 2007ebe:	b500      	push	{lr}
 2007ec0:	4807      	ldr	r0, [pc, #28]	@ (2007ee0 <a+0x24>)
 2007ec2:	b083      	sub	sp, #12
 2007ec4:	0089      	lsls	r1, r1, #2
 2007ec6:	f000 e810 	blx	2007ee8 <__aaa_from_thumb>
 2007eca:	de00      	udf	#0
 2007ecc:	466b      	mov	r3, sp
 2007ece:	1dda      	adds	r2, r3, #7
 2007ed0:	2301      	movs	r3, #1
 2007ed2:	7013      	strb	r3, [r2, #0]
 2007ed4:	7813      	ldrb	r3, [r2, #0]
 2007ed6:	2b00      	cmp	r3, #0
 2007ed8:	d1fc      	bne.n	2007ed4 <a+0x18>
 2007eda:	b003      	add	sp, #12
 2007edc:	bd00      	pop	{pc}
 2007ede:	46c0      	nop			@ (mov r8, r8)
 2007ee0:	02006ff0 	.word	0x02006ff0
 2007ee4:	00000000 	.word	0x00000000

02007ee8 <__aaa_from_thumb>:
 2007ee8:	e51ff004 	ldr	pc, [pc, #-4]	@ 2007eec <__aaa_from_thumb+0x4>
 2007eec:	01000000 	.word	0x01000000
```
The bug manifests in the `blx	2007ee8 ` instruction not actually ending up calling the interwork code, but by jumping to a random ram address.
Attached is a full blocksds project that will always end up crashing at startup when launched by any of the homebrew loaders (the dsi system launcher seems to be the only one properly launching this code, likely because it's already preloading the twl binaries to ram).
If the test project is compiled with this crt change, or with the `DC_FlushAll` function uncommented, it will instead work as expected (crashing with an undefined instruction inside the function `a`)