### PR TITLE
Improve Makefile version check with the ability to get results

### DIFF
--- a/libs/libblocksds/Makefile
+++ b/libs/libblocksds/Makefile
@@ -51,7 +51,7 @@ all:
 	@$(MKDIR) -p build
 	@echo "  GENERATE VERSION HEADER"
 	@bash generate_version_header.sh $(VERSION_STRING) \
-		build/blocksds_version.h build/blocksds_version.make
+		build/blocksds_version.h build/blocksds_version.make fixed_makefile_part
 
 clean:
 	@echo "  CLEAN"

--- a/libs/libblocksds/fixed_makefile_part
+++ b/libs/libblocksds/fixed_makefile_part
@@ -1,0 +1,42 @@
+# Returns the number corresponding to the specified blocksds version.
+# Use it like this: $(call blocksds_version_to_full, 1, 12, 2)
+blocksds_version_to_full = $(shell expr \( $(1) \* 65536 + $(2) \* 256 + $(3) \) )
+
+# Integer that represents the version number of this build
+BLOCKSDS_VERSION_FULL = $(call blocksds_version_to_full, ${BLOCKSDS_VERSION_MAJOR}, ${BLOCKSDS_VERSION_MINOR}, ${BLOCKSDS_VERSION_PATCH})
+
+# Returns 1 if the version of BlocksDS matches. Returns 0 otherwise.
+# Use it like this: $(call blocksds_version_equals, 1, 12, 2)
+blocksds_version_equals = $(shell expr $(BLOCKSDS_VERSION_FULL) == $(call blocksds_version_to_full, $1, $2, $3))
+
+# Returns 1 if the version of BlocksDS is high enough. Returns 0 otherwise.
+# Use it like this: $(call blocksds_version_at_least, 1, 12, 2)
+blocksds_version_at_least = $(shell expr $(BLOCKSDS_VERSION_FULL) \>= $(call blocksds_version_to_full, $1, $2, $3))
+
+# Returns 1 if the version of BlocksDS is low enough. Returns 0 otherwise.
+# Use it like this: $(call blocksds_version_at_most, 1, 12, 2)
+blocksds_version_at_most = $(shell expr $(BLOCKSDS_VERSION_FULL) \<= $(call blocksds_version_to_full, $1, $2, $3))
+
+# Causes an error if the version of BlocksDS isn't high enough
+# Use it like this: $(eval $(call error_if_blocksds_version_different, 1, 12, 2))
+define error_if_blocksds_version_different
+    ifneq ($(call blocksds_version_equals, $1, $2, $3), 1)
+        $$(error Version of BlocksDS doesn't match)
+    endif
+endef
+
+# Causes an error if the version of BlocksDS isn't high enough
+# Use it like this: $(eval $(call error_if_blocksds_version_less_than, 1, 12, 2))
+define error_if_blocksds_version_less_than
+    ifneq ($(call blocksds_version_at_least, $1, $2, $3), 1)
+        $$(error Version of BlocksDS is too small)
+    endif
+endef
+
+# Causes an error if the version of BlocksDS isn't low enough
+# Use it like this: $(eval $(call error_if_blocksds_version_greater_than, 1, 12, 2))
+define error_if_blocksds_version_greater_than
+    ifneq ($(call blocksds_version_at_most, $1, $2, $3), 1)
+        $$(error Version of BlocksDS is too big)
+    endif
+endef

--- a/libs/libblocksds/generate_version_header.sh
+++ b/libs/libblocksds/generate_version_header.sh
@@ -4,16 +4,17 @@
 #
 # Copyright (C) 2025 Antonio Niño Díaz
 
-if [[ $# -ne 3 ]]; then
+if [[ $# -ne 4 ]]; then
     echo "Invalid number of arguments"
     echo
-    echo "Usage: $0 <version> <out header path> <out makefile path>"
+    echo "Usage: $0 <version> <out header path> <out makefile path> <fixed_makefile_part path>"
     exit 1
 fi
 
 VERSION_STRING=$1
 OUT_HEADER_PATH=$2
 OUT_MAKEFILE_PATH=$3
+FIXED_MAKEFILE_PATH=$4
 
 # Split version string into its components
 # ========================================
@@ -96,8 +97,6 @@ EOF
 # Export Makefile
 # ===============
 
-full=$(( ${major} * 65536 + ${minor} * 256 + ${patch} ))
-
 cat <<EOF > ${OUT_MAKEFILE_PATH}
 # SPDX-License-Identifier: Zlib
 #
@@ -108,38 +107,14 @@ BLOCKSDS_VERSION_MAJOR = ${major}
 BLOCKSDS_VERSION_MINOR = ${minor}
 BLOCKSDS_VERSION_PATCH = ${patch}
 
-# Integer that represents the version number of this build
-BLOCKSDS_VERSION_FULL = ${full}
-
 # Full version string
 BLOCKSDS_VERSION_STRING = ${VERSION_STRING}
 
 # This is 1 if the current build of BlocksDS is a tagged (official) release
 BLOCKSDS_VERSION_IS_TAGGED = ${tagged_version}
 
-# Causes an error if the version of BlocksDS isn't high enough
-# Use it like this: \$(eval \$(call blocksds_version_equals, 1, 12, 2))
-define blocksds_version_equals
-    ifeq (\$(shell expr ${full} == \( \$(1) \* 65536 + \$(2) \* 256 + \$(3) \) ),0)
-        \$\$(error Version of BlocksDS doesn't match)
-    endif
-endef
-
-# Causes an error if the version of BlocksDS isn't high enough
-# Use it like this: \$(eval \$(call blocksds_version_at_least, 1, 12, 2))
-define blocksds_version_at_least
-    ifeq (\$(shell expr ${full} \>= \( \$(1) \* 65536 + \$(2) \* 256 + \$(3) \) ),0)
-        \$\$(error Version of BlocksDS is too small)
-    endif
-endef
-
-# Causes an error if the version of BlocksDS isn't low enough
-# Use it like this: \$(eval \$(call blocksds_version_at_most, 1, 12, 2))
-define blocksds_version_at_most
-    ifeq (\$(shell expr ${full} \<= \( \$(1) \* 65536 + \$(2) \* 256 + \$(3) \) ),0)
-        \$\$(error Version of BlocksDS is too big)
-    endif
-endef
 EOF
+
+cat ${FIXED_MAKEFILE_PATH} >> ${OUT_MAKEFILE_PATH}
 
 exit 0

--- a/libs/libblocksds/readme.md
+++ b/libs/libblocksds/readme.md
@@ -41,7 +41,13 @@ int main(int argc, char *argv[])
 At the end of your makefile add the following line:
 
 ```make
-include $(BLOCKSDS)/libs/libblocksds/make/blocksds_version.make
+BLOCKSDS_VERSION_FILE = $(BLOCKSDS)/libs/libblocksds/make/blocksds_version.make
+
+ifeq ("$(wildcard $(BLOCKSDS_VERSION_FILE))","")
+$(error BlocksDS version too old. Please update.)
+endif
+
+include $(BLOCKSDS_VERSION_FILE)
 ```
 
 After that line you can use it like this, for example:


### PR DESCRIPTION
This makes it so blocksds_version_equals, blocksds_version_at_least and blocksds_version_at_most return 0 or 1 when called.
This is because previously the makefile would just error out if you used $(eval $(call ...)), with no way to do anything to handle the case for the user.
Now, the user can $(call ...) the functions to decide what to do with their result.

Then, it introduces the functions error_if_blocksds_version_different, error_if_blocksds_version_less_than and error_if_blocksds_version_greater_than, which an user may call to use the default error handling.

This improves flexibility, due to separating the logic from the error handling.

It also improves the readme by adding to the makefile example proper handling of the older release versions.
