### PR TITLE
volumetric shadow - Fixed wrong normal orientation for planes

### DIFF
--- a/examples/graphics_3d/volumetric_shadow/source/main.c
+++ b/examples/graphics_3d/volumetric_shadow/source/main.c
@@ -9,7 +9,7 @@
 
 void DrawFloor(void)
 {
-    glNormal3f(0, -0.97, 0);
+    glNormal3f(0, 0.97, 0);
 
     glBegin(GL_QUAD);
 
@@ -30,7 +30,7 @@ void DrawFloor(void)
 
 void DrawLid(void)
 {
-    glNormal3f(0, -0.97, 0);
+    glNormal3f(0, 0.97, 0);
 
     glBegin(GL_QUAD);
 


### PR DESCRIPTION
The floor and the lid had the normal facing downwards, even though logically they should be facing upwards to be illuminated by the down shining sun