### PR TITLE
Add DSone & R4i Gold 3DS Plus to ARM7 DLDI support table

### DIFF
--- a/docs/content/docs/guides/dldi_arm7.md
+++ b/docs/content/docs/guides/dldi_arm7.md
@@ -88,6 +88,7 @@ and report your findings.
 flashcart         | ARM9 | ARM7 | Notes
 ------------------|------|------|------
 Acekard 2i        | Yes  | Yes  |
+SuperCard DSONE   | Yes  | Yes  |
 SuperCard DSTWO   | Yes  | Yes  |
 Original R4       | Yes  | Yes  |
 DSpico            | Yes  | Yes  |


### PR DESCRIPTION
I've run tests_fs_dldi_arm7_arm9.nds on both of these to be sure! I got these results using the cards' stock DLDIs, with names `DSONE(Slot-1)` and `R4iDSN`. I figured I should put the DSone before the DStwo, but I just put the other card at the end for lack of a better place.