### PR TITLE
fix renaming of the defaultExceptionHandler()

### DIFF
--- a/examples/debug/exception_handler/arm9/source/main.c
+++ b/examples/debug/exception_handler/arm9/source/main.c
@@ -28,7 +28,7 @@ int main(int argc, char **argv)
     // As explained above, this isn't required in debug builds, only in release
     // builds. In debug builds this is called before reaching main(). In release
     // builds, this replaces the minimal release exception handler.
-    debugExceptionHandler();
+    defaultExceptionHandler();
     //releaseExceptionHandler();
 
     consoleDemoInit();


### PR DESCRIPTION
defaultExceptionHandler() hasn't changed name with the addition of releaseExceptionHandler in b464c95f05b14d16a32d137e0cfe873ddc259014


